### PR TITLE
Implement inject.Named which can be used to create bindings on demand

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@ Dependency injection for the XP Framework change log
 
 ## ?.?.? / ????-??-??
 
+* Added class `inject.Named`. Extending from this class will allow to
+  create bindings on demand.
+  (@thekid)
 * Improved error messages when injecting fields and parameters
   (@thekid)
 * Changed `@inject` annotation behavior:
@@ -20,7 +23,7 @@ Dependency injection for the XP Framework change log
   (@thekid)
 * Removed `inject.XPInjector`. Its name is misleading, its implementation
   dependant on whether certain other modules are loaded or not. It should
-  be called `LegacyInjector` or somethong. I'll leave this to another place
+  be called `LegacyInjector` or something. If necessary, use `inject.Named`. 
   (@thekid)
 
 ## 0.4.0 / 2015-01-10

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ The inject package contains the XP framework's dependency injection API. Its ent
 
 Binding
 -------
-Values can be bound to the injector by using its `bind()` method. It accepts the type to bind to, an optional name and three different scenarios:
+Values can be bound to the injector by using its `bind()` method. It accepts the type to bind to, an optional name and these different scenarios:
 
 * **Binding a class**: The typical usecase, where we bind an interface to its concrete implementation.
 * **Binding an instance**: By binding a type to an existing instance, we can create a *singleton* model.
 * **Binding a provider**: If we need more complicated code to create an instance, we can bind to a provider.
+* **Binding a named lookup**: If we want control over the binding lookups for a type, we can bind to a `Named` instance.
 
 ```php
 use inject\Injector;
@@ -113,5 +114,22 @@ $provider= $injector->get('inject.Provider<com.example.writers.ReportWriter>');
 
 // ...later on
 $instance= $provider->get();
+```
+
+Named lookups
+-------------
+If we need control over the lookup, we can bind instances of `Named`:
+
+```php
+use inject\Injector;
+use inject\InstanceBinding;
+
+$inject= new Injector();
+$inject->bind('com.example.Value', newinstance('inject.Named', [], [
+  'provides' => function($name) { return true; },
+  'binding'  => function($name) { return new InstanceBinding(new Value($name)); }
+]));
+
+$value= $inject->get('com.example.Value', 'default');  // new Value("default")
 ```
 

--- a/src/main/php/inject/ClassBinding.class.php
+++ b/src/main/php/inject/ClassBinding.class.php
@@ -3,24 +3,22 @@
 use lang\IllegalArgumentException;
 
 class ClassBinding extends \lang\Object implements Binding {
-  protected $type;
   protected $class;
 
   /**
    * Creates a new instance binding
    *
-   * @param  lang.XPClass $type
    * @param  lang.XPClass $class
+   * @param  lang.XPClass $type
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($type, $class) {
+  public function __construct($class, $type) {
     if (!$type->isAssignableFrom($class)) {
       throw new IllegalArgumentException($class.' is not an instance of '.$type);
     } else if ($class->isInterface() || $class->getModifiers() & MODIFIER_ABSTRACT) {
       throw new IllegalArgumentException('Cannot bind to non-concrete type '.$type);
     }
 
-    $this->type= $type;
     $this->class= $class;
   }
 

--- a/src/main/php/inject/ClassBinding.class.php
+++ b/src/main/php/inject/ClassBinding.class.php
@@ -12,8 +12,8 @@ class ClassBinding extends \lang\Object implements Binding {
    * @param  lang.XPClass $type
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($class, $type) {
-    if (!$type->isAssignableFrom($class)) {
+  public function __construct($class, $type= null) {
+    if ($type && !$type->isAssignableFrom($class)) {
       throw new IllegalArgumentException($class.' is not an instance of '.$type);
     } else if ($class->isInterface() || $class->getModifiers() & MODIFIER_ABSTRACT) {
       throw new IllegalArgumentException('Cannot bind to non-concrete type '.$type);

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -88,7 +88,7 @@ class Injector extends \lang\Object {
   /**
    * Get a binding
    *
-   * @param  var $type either a lang.Type instance or a type name
+   * @param  string|lang.Type $type
    * @param  string $name
    * @return var or NULL if none exists
    */

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -40,13 +40,13 @@ class Injector extends \lang\Object {
    */
   protected function asBinding($t, $impl) {
     if ($impl instanceof XPClass) {
-      return new ClassBinding($t, $impl);
+      return new ClassBinding($impl, $t);
     } else if (self::$PROVIDER->isInstance($impl) || $impl instanceof Provider) {
-      return new ProviderBinding($t, $impl);
+      return new ProviderBinding($impl);
     } else if ($impl instanceof Generic) {
-      return new InstanceBinding($t, $impl);
+      return new InstanceBinding($impl, $t);
     } else {
-      return new ClassBinding($t, XPClass::forName((string)$impl));
+      return new ClassBinding(XPClass::forName((string)$impl), $t);
     }
   }
 
@@ -73,14 +73,15 @@ class Injector extends \lang\Object {
   public function bind($type, $impl, $name= null) {
     $t= $type instanceof Type ? $type : Type::forName($type);
 
-    if ($t instanceof XPClass) {
-      $this->bindings[$t->literal().$name]= $this->asBinding($t, $impl);
+    if ($impl instanceof Named) {
+      $this->bindings[$t->literal()]= $impl;
+    } else if ($t instanceof XPClass) {
+      $this->bindings[$t->literal()][$name]= $this->asBinding($t, $impl);
     } else if (null === $name) {
       throw new IllegalArgumentException('Cannot bind non-class type '.$t.' without a name');
     } else {
-      $this->bindings[$t->literal().$name]= new InstanceBinding($t, $impl);
+      $this->bindings[$t->literal()][$name]= new InstanceBinding($impl, $t);
     }
-
     return $this;
   }
 
@@ -95,16 +96,19 @@ class Injector extends \lang\Object {
     $t= $type instanceof Type ? $type : Type::forName($type);
 
     if (self::$PROVIDER->isAssignableFrom($t)) {
-      if (isset($this->bindings[$combined= $t->genericArguments()[0]->literal().$name])) {
-        return $this->bindings[$combined]->provider($this);
+      $literal= $t->genericArguments()[0]->literal();
+      if (isset($this->bindings[$literal][$name])) {
+        return $this->bindings[$literal][$name]->provider($this);
       }
     } else {
-      if (isset($this->bindings[$combined= $t->literal().$name])) {
-        return $this->bindings[$combined]->resolve($this);
-      } else if ($t instanceof XPClass && !($t->isInterface() || $t->getModifiers() & MODIFIER_ABSTRACT)) {
+      $literal= $t->literal();
+      if (isset($this->bindings[$literal][$name])) {
+        return $this->bindings[$literal][$name]->resolve($this);
+      } else if (null === $name && $t instanceof XPClass && !($t->isInterface() || $t->getModifiers() & MODIFIER_ABSTRACT)) {
         return $this->newInstance($t);
       }
     }
+
     return null;
   }
 

--- a/src/main/php/inject/InstanceBinding.class.php
+++ b/src/main/php/inject/InstanceBinding.class.php
@@ -4,21 +4,19 @@ use lang\IllegalArgumentException;
 use util\Objects;
 
 class InstanceBinding extends \lang\Object implements Binding {
-  protected $type;
   protected $instance;
 
   /**
    * Creates a new instance binding
    *
-   * @param  lang.Type $type
    * @param  var $instance
+   * @param  lang.Type $type
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($type, $instance) {
-    if (!$type->isInstance($instance)) {
+  public function __construct($instance, $type= null) {
+    if ($type && !$type->isInstance($instance)) {
       throw new IllegalArgumentException(Objects::stringOf($instance).' is not an instance of '.$type);
     }
-    $this->type= $type;
     $this->instance= $instance;
   }
 

--- a/src/main/php/inject/Named.class.php
+++ b/src/main/php/inject/Named.class.php
@@ -1,0 +1,33 @@
+<?php namespace inject;
+
+/**
+ * Base class for named lookups
+ *
+ * @test  xp://inject.unittest.NamedInstancesTest
+ */
+abstract class Named extends \lang\Object implements \ArrayAccess {
+
+  /**
+   * Returns whether this named instance provides a given name
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public abstract function provides($name);
+
+  /**
+   * Returns the binding
+   *
+   * @param  string $name
+   * @return inject.Binding
+   */
+  public abstract function binding($name);
+
+  public function offsetExists($offset) { return $this->provides($offset); }
+
+  public function offsetGet($offset) { return $this->binding($offset); }
+
+  public function offsetSet($offset, $value) { /* Empty */ }
+
+  public function offsetUnset($offset) { /* Empty */ }
+}

--- a/src/main/php/inject/Named.class.php
+++ b/src/main/php/inject/Named.class.php
@@ -3,7 +3,7 @@
 /**
  * Base class for named lookups
  *
- * @test  xp://inject.unittest.NamedInstancesTest
+ * @test  xp://inject.unittest.NamedTest
  */
 abstract class Named extends \lang\Object implements \ArrayAccess {
 

--- a/src/main/php/inject/ProviderBinding.class.php
+++ b/src/main/php/inject/ProviderBinding.class.php
@@ -3,18 +3,15 @@
 use lang\IllegalArgumentException;
 
 class ProviderBinding extends \lang\Object implements Binding {
-  protected $type;
   protected $provider;
 
   /**
    * Creates a new provider binding
    *
-   * @param  lang.XPClass $type
    * @param  inject.Provider $provider
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($type, $provider) {
-    $this->type= $type;
+  public function __construct($provider) {
     $this->provider= $provider;
   }
 

--- a/src/test/php/inject/unittest/NamedInstancesTest.class.php
+++ b/src/test/php/inject/unittest/NamedInstancesTest.class.php
@@ -1,0 +1,31 @@
+<?php namespace inject\unittest;
+
+use inject\Injector;
+use inject\InstanceBinding;
+use inject\unittest\fixture\Value;
+use lang\Type;
+
+class NamedInstancesTest extends \unittest\TestCase {
+
+  #[@test]
+  public function providing_named_values() {
+    $inject= new Injector();
+    $inject->bind('inject.unittest.fixture.Value', newinstance('inject.Named', [], [
+      'provides' => function($name) { return true; },
+      'binding'  => function($name) { return new InstanceBinding(new Value($name)); }
+    ]));
+
+    $this->assertEquals(new Value('default'), $inject->get('inject.unittest.fixture.Value', 'default'));
+  }
+
+  #[@test]
+  public function get_returns_null_if_provides_returns_false() {
+    $inject= new Injector();
+    $inject->bind('inject.unittest.fixture.Value', newinstance('inject.Named', [], [
+      'provides' => function($name) { return false; },
+      'binding'  => function($name) { throw new IllegalStateException('Should not be reached'); }
+    ]));
+
+    $this->assertNull($inject->get('inject.unittest.fixture.Value', 'default'));
+  }
+}

--- a/src/test/php/inject/unittest/NamedTest.class.php
+++ b/src/test/php/inject/unittest/NamedTest.class.php
@@ -39,4 +39,15 @@ class NamedTest extends \unittest\TestCase {
 
     $this->assertNull($inject->get('inject.unittest.fixture.Value', 'default'));
   }
+
+  #[@test]
+  public function using_a_provider() {
+    $inject= new Injector();
+    $inject->bind('inject.unittest.fixture.Value', newinstance('inject.Named', [], [
+      'provides' => function($name) { return true; },
+      'binding'  => function($name) { return new InstanceBinding(new Value($name)); }
+    ]));
+
+    $this->assertEquals(new Value('default'), $inject->get('inject.Provider<inject.unittest.fixture.Value>', 'default')->get());
+  }
 }

--- a/src/test/php/inject/unittest/NamedTest.class.php
+++ b/src/test/php/inject/unittest/NamedTest.class.php
@@ -5,7 +5,7 @@ use inject\InstanceBinding;
 use inject\unittest\fixture\Value;
 use lang\Type;
 
-class NamedInstancesTest extends \unittest\TestCase {
+class NamedTest extends \unittest\TestCase {
 
   #[@test]
   public function providing_named_values() {

--- a/src/test/php/inject/unittest/NamedTest.class.php
+++ b/src/test/php/inject/unittest/NamedTest.class.php
@@ -19,6 +19,17 @@ class NamedTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function providing_without_name() {
+    $inject= new Injector();
+    $inject->bind('inject.unittest.fixture.Value', newinstance('inject.Named', [], [
+      'provides' => function($name) { return true; },
+      'binding'  => function($name) { return new InstanceBinding(new Value($name)); }
+    ]));
+
+    $this->assertEquals(new Value(null), $inject->get('inject.unittest.fixture.Value'));
+  }
+
+  #[@test]
   public function get_returns_null_if_provides_returns_false() {
     $inject= new Injector();
     $inject->bind('inject.unittest.fixture.Value', newinstance('inject.Named', [], [

--- a/src/test/php/inject/unittest/fixture/Value.class.php
+++ b/src/test/php/inject/unittest/fixture/Value.class.php
@@ -3,7 +3,7 @@
 class Value extends \lang\Object {
   private $backing;
 
-  /** @param var $initial */
+  /** @param string $initial */
   public function __construct($initial) { $this->backing= $initial; }
 
   /**

--- a/src/test/php/inject/unittest/fixture/Value.class.php
+++ b/src/test/php/inject/unittest/fixture/Value.class.php
@@ -1,5 +1,18 @@
 <?php namespace inject\unittest\fixture;
 
 class Value extends \lang\Object {
+  private $backing;
 
+  /** @param var $initial */
+  public function __construct($initial) { $this->backing= $initial; }
+
+  /**
+   * Returns whether another value is equal to this
+   *
+   * @param  var $cmp
+   * @return bool
+   */
+  public function equals($cmp) {
+    return $cmp instanceof self && $this->backing === $cmp->backing;
+  }
 }


### PR DESCRIPTION
Example: 

```php
use inject\Injector;
use inject\InstanceBinding;

$inject= new Injector();
$inject->bind('com.example.Value', newinstance('inject.Named', [], [
  'provides' => function($name) { return true; },
  'binding'  => function($name) { return new InstanceBinding(new Value($name)); }
]));

$value= $inject->get('com.example.Value', 'default');  // new Value("default")
```