### PR TITLE
Add inject.ConfiguredBindings class which reads from a properties file

### DIFF
--- a/src/main/php/inject/ConfiguredBindings.class.php
+++ b/src/main/php/inject/ConfiguredBindings.class.php
@@ -1,6 +1,7 @@
 <?php namespace inject;
 
 use util\PropertyAccess;
+use util\Properties;
 use lang\XPClass;
 
 /**
@@ -16,8 +17,14 @@ use lang\XPClass;
 class ConfiguredBindings extends Bindings {
   private $properties;
 
-  /** @param util.PropertyAccess */
-  public function __construct(PropertyAccess $properties) { $this->properties= $properties; }
+  /** @param util.PropertyAccess|string */
+  public function __construct($arg) {
+    if ($arg instanceof PropertyAccess) {
+      $this->properties= $arg;
+    } else {
+      $this->properties= new Properties($arg);
+    }
+  }
 
   /**
    * Parse arguments from a string. Supports strings, booleans, null, and numbers.

--- a/src/main/php/inject/ConfiguredBindings.class.php
+++ b/src/main/php/inject/ConfiguredBindings.class.php
@@ -1,0 +1,102 @@
+<?php namespace inject;
+
+use util\PropertyAccess;
+use lang\XPClass;
+
+/**
+ * Bindings from a properties file
+ *
+ * ```ini
+ * scriptlet.Session=com.example.session.FileSystem
+ * scriptlet.Session=com.example.session.MemCache("tcp://localhost:11211")
+ * ```
+ *
+ * @test    xp://inject.unittest.ConfiguredBindingsTest
+ */
+class ConfiguredBindings extends Bindings {
+  private $properties;
+
+  /** @param util.PropertyAccess */
+  public function __construct(PropertyAccess $properties) { $this->properties= $properties; }
+
+  /**
+   * Parse arguments from a string. Supports strings, booleans, null, and numbers.
+   *
+   * @param  string $input
+   * @return var[]
+   */
+  private function argumentsIn($input) {
+    if ('' === $input) return [];
+
+    $arguments= [];
+    foreach (explode(',', $input) as $arg) {
+      if ('"' === $arg{0} || "'" === $arg{0}) {
+        $arguments[]= strtr(substr($arg, 1, -1), ['\\'.$arg{0} => $arg{0}]);
+      } else if (0 === strncasecmp($arg, 'true', 4)) {
+        $arguments[]= true;
+      } else if (0 === strncasecmp($arg, 'false', 5)) {
+        $arguments[]= false;
+      } else if (0 === strncasecmp($arg, 'null', 4)) {
+        $arguments[]= null;
+      } else if (strstr($arg, '.')) {
+        $arguments[]= (double)$arg;
+      } else {
+        $arguments[]= (int)$arg;
+      }
+    }
+    return $arguments;
+  }
+
+  /**
+   * Resolves a name
+   *
+   * @param  string $namespace
+   * @param  string $name
+   * @return lang.XPClass
+   */
+  private function resolveType($namespace, $name) {
+    return XPClass::forName(strstr($name, '.') ? $name : $namespace.'.'.$name);
+  }
+
+  /**
+   * Parse implementation from a string.
+   *
+   * @param  string $namespace
+   * @param  string $input
+   * @return var
+   */
+  private function bindingTo($namespace, $input) {
+    if (false === ($p= strpos($input, '('))) {
+      return $this->resolveType($namespace, $input);
+    } else {
+      $class= $this->resolveType($namespace, substr($input, 0, $p));
+      if ($class->hasConstructor()) {
+        $arguments= $this->argumentsIn(substr($input, $p + 1, -1));
+        return $class->getConstructor()->newInstance($arguments);
+      } else {
+        return $class->newInstance();
+      }
+    }
+  }
+
+  /**
+   * Configures bindings on given injector
+   *
+   * @param  inject.Injector $injector
+   */
+  public function configure($injector) {
+    $namespace= $this->properties->getFirstSection();
+    do {
+      foreach ($this->properties->readSection($namespace) as $name => $implementation) {
+        $type= $this->resolveType($namespace, $name);
+        if (is_array($implementation)) {
+          foreach ($implementation as $name => $impl) {
+            $injector->bind($type, $this->bindingTo($namespace, $impl), $name);
+          }
+        } else {
+          $injector->bind($type, $this->bindingTo($namespace, $implementation));
+        }
+      }
+    } while ($namespace= $this->properties->getNextSection());
+  }
+}

--- a/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
+++ b/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
@@ -34,6 +34,18 @@ class ConfiguredBindingsTest extends \unittest\TestCase {
     $this->assertEquals(new FileSystem('/usr'), $inject->get('inject.unittest.fixture.Storage'));
   }
 
+  #[@test, @values([
+  #  ['string[test]="Test"', 'string', 'Test'],
+  #  ['int[test]=6100', 'int', 6100],
+  #  ['double[test]=1.5', 'double', 1.5],
+  #  ['bool[test]=true', 'bool', true],
+  #  ['bool[test]=false', 'bool', false]
+  #])]
+  public function bind_primitive($line, $type, $expected) {
+    $inject= new Injector(new ConfiguredBindings(Properties::fromString($line)));
+    $this->assertEquals($expected, $inject->get($type, 'test'));
+  }
+
   #[@test]
   public function bind_named_class() {
     $inject= new Injector(new ConfiguredBindings(Properties::fromString('

--- a/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
+++ b/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
@@ -1,0 +1,88 @@
+<?php namespace inject\unittest;
+
+use inject\Injector;
+use inject\ConfiguredBindings;
+use util\Properties;
+use inject\unittest\fixture\Value;
+use inject\unittest\fixture\FileSystem;
+
+class ConfiguredBindingsTest extends \unittest\TestCase {
+
+  #[@test]
+  public function bind_class() {
+    $inject= new Injector(new ConfiguredBindings(Properties::fromString('
+      inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem
+    ')));
+    $this->assertEquals(new FileSystem(), $inject->get('inject.unittest.fixture.Storage'));
+  }
+
+  #[@test]
+  public function bind_instance() {
+    $inject= new Injector(new ConfiguredBindings(Properties::fromString('
+      inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem("/usr")
+    ')));
+    $this->assertEquals(new FileSystem('/usr'), $inject->get('inject.unittest.fixture.Storage'));
+  }
+
+  #[@test]
+  public function bind_named_class() {
+    $inject= new Injector(new ConfiguredBindings(Properties::fromString('
+      inject.unittest.fixture.Storage[files]=inject.unittest.fixture.FileSystem
+    ')));
+    $this->assertEquals(new FileSystem(), $inject->get('inject.unittest.fixture.Storage', 'files'));
+  }
+
+  #[@test]
+  public function bind_named_instance() {
+    $inject= new Injector(new ConfiguredBindings(Properties::fromString('
+      inject.unittest.fixture.Storage[files]=inject.unittest.fixture.FileSystem("/usr")
+    ')));
+    $this->assertEquals(new FileSystem('/usr'), $inject->get('inject.unittest.fixture.Storage', 'files'));
+  }
+
+  #[@test]
+  public function bind_multiple() {
+    $inject= new Injector(new ConfiguredBindings(Properties::fromString('
+      inject.unittest.fixture.Storage[user]=inject.unittest.fixture.FileSystem("~/.xp")
+      inject.unittest.fixture.Storage[system]=inject.unittest.fixture.FileSystem("/etc/xp")
+    ')));
+    $this->assertEquals(
+      [new FileSystem('~/.xp'), new FileSystem('/etc/xp')],
+      [$inject->get('inject.unittest.fixture.Storage', 'user'), $inject->get('inject.unittest.fixture.Storage', 'system')]
+    );
+  }
+
+  #[@test, @values([
+  #  ['null', null],
+  #  ['true', true],
+  #  ['false', false],
+  #  ['0', 0], ['-1', -1], ['1', 1],
+  #  ['0.0', 0.0], ['-1.5', -1.5], ['1.5', 1.5],
+  #  ['"test"', 'test'], ['"\"test\""', '"test"'],
+  #  ["'test'", 'test'], ["'\'test\''", "'test'"]
+  #])]
+  public function bind_instance_with($param, $expected) {
+    $inject= new Injector(new ConfiguredBindings(Properties::fromString('
+      inject.unittest.fixture.Value=inject.unittest.fixture.Value('.$param.')
+    ')));
+    $this->assertEquals(new Value($expected), $inject->get('inject.unittest.fixture.Value'));
+  }
+
+  #[@test, @values([
+  #  'Storage=FileSystem',
+  #  'Storage=FileSystem()',
+  #  'Storage=inject.unittest.fixture.FileSystem',
+  #  'Storage=inject.unittest.fixture.FileSystem()',
+  #  'inject.unittest.fixture.Storage=FileSystem',
+  #  'inject.unittest.fixture.Storage=FileSystem()',
+  #  'inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem',
+  #  'inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem()'
+  #])]
+  public function uses_propertyfile_sections_as_namespace($line) {
+    $inject= new Injector(new ConfiguredBindings(Properties::fromString('
+      [inject.unittest.fixture]
+      '.$line.'
+    ')));
+    $this->assertEquals(new FileSystem(), $inject->get('inject.unittest.fixture.Storage'));
+  }
+}

--- a/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
+++ b/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
@@ -9,6 +9,16 @@ use inject\unittest\fixture\FileSystem;
 class ConfiguredBindingsTest extends \unittest\TestCase {
 
   #[@test]
+  public function can_create_with_properties() {
+    new ConfiguredBindings(new Properties('test.ini'));
+  }
+
+  #[@test]
+  public function can_create_with_filename() {
+    new ConfiguredBindings('test.ini');
+  }
+
+  #[@test]
   public function bind_class() {
     $inject= new Injector(new ConfiguredBindings(Properties::fromString('
       inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem

--- a/src/test/php/inject/unittest/fixture/Value.class.php
+++ b/src/test/php/inject/unittest/fixture/Value.class.php
@@ -1,9 +1,11 @@
 <?php namespace inject\unittest\fixture;
 
+use util\Objects;
+
 class Value extends \lang\Object {
   private $backing;
 
-  /** @param string $initial */
+  /** @param var $initial */
   public function __construct($initial) { $this->backing= $initial; }
 
   /**
@@ -13,6 +15,6 @@ class Value extends \lang\Object {
    * @return bool
    */
   public function equals($cmp) {
-    return $cmp instanceof self && $this->backing === $cmp->backing;
+    return $cmp instanceof self && Objects::equal($this->backing, $cmp->backing);
   }
 }


### PR DESCRIPTION
## Examples

Binding to a class:
```ini
scriptlet.Session=com.example.session.FileSystem
```

Binding to an instance, passing parameters:
```ini
scriptlet.Session=com.example.session.MemCache("tcp://localhost:11211")
```

Binding primitives:
```ini
string[api-key]="6c51b0830a9ab74cc8cbe"
bool[use-api]=true
```

Using namespaces:
```ini
[com.example.session]
scriptlet.Session=Redis("user:pass@localhost")
```

Using ConfiguredBindings for the Injector.
```php
$inject= new Injector(new ConfiguredBindings('bindings.ini'));
$session= $inject->get('scriptlet.Session');
$apiKey= $inject->get('string', 'api-key');
```

Inside an XPCLI:
```php
use util\PropertyAccess;

class Test extends \util\cmd\Command {
  private $inject;

  #[@inject(name= 'bindings')]
  public function useInjector(PropertyAccess $prop) {
    $this->inject= new Injector(new ConfiguredBindings($prop));
  }

  // ....
}