### PR TITLE
New syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,10 @@
 language: php
 
 php:
-  - hhvm
   - nightly
 
-matrix:
-  allow_failures:
-    - php: nightly
-
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.2.0/setup' -O - | php
+  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.5.0/setup' -O - | php
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
   - echo "use=vendor/xp-framework/core" > xp.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - hhvm
   - nightly
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "~6.0",
-    "php" : ">=5.4.0"
+    "php" : ">=7.0.0"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -92,7 +92,7 @@ class Injector extends \lang\Object {
    * @param  string $name
    * @return var or NULL if none exists
    */
-  public function get($type, $name= null) {
+  public function new($type, $name= null) {
     $t= $type instanceof Type ? $type : Type::forName($type);
 
     if (self::$PROVIDER->isAssignableFrom($t)) {
@@ -110,6 +110,17 @@ class Injector extends \lang\Object {
     }
 
     return null;
+  }
+
+  /**
+   * Get a binding
+   *
+   * @param  string|lang.Type $type
+   * @param  string $name
+   * @return var or NULL if none exists
+   */
+  public function get($type, $name= null) {
+    return $this->new($type, $name);
   }
 
   /**

--- a/src/test/php/inject/unittest/InjectorTest.class.php
+++ b/src/test/php/inject/unittest/InjectorTest.class.php
@@ -147,4 +147,11 @@ class InjectorTest extends TestCase {
     $inject->bind($type, $impl, 'test');
     $this->assertNull($inject->get($type, 'another-name-than-the-one-bound'));
   }
+
+  #[@test]
+  public function using_new() {
+    $inject= new Injector();
+    $inject->bind('inject.unittest.fixture.Storage', 'inject.unittest.fixture.FileSystem');
+    $this->assertInstanceOf('inject.unittest.fixture.FileSystem', $inject->new('inject.unittest.fixture.Storage'));
+  }
 }


### PR DESCRIPTION
This pull request introduces a new way (pun intended!) to use the injector:

```php
// Before
$instance= $injector->get(T::class);

// After
$instance= $injector->new(T::class);
```

BC is kept w/ the `get()` verb but support for PHP 5.x is dropped - this feature relies on the [context sensitive lexer RFC](https://wiki.php.net/rfc/context_sensitive_lexer)