### PR TITLE
Enter PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: php
 sudo: false
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ php:
   - hhvm
   - nightly
 
-matrix:
-  allow_failures:
-    - php: nightly
-
 before_script:
   - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.5.0/setup' -O - | php
   - composer install --prefer-dist

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Inject
 [![Build Status on TravisCI](https://secure.travis-ci.org/xp-forge/inject.svg)](http://travis-ci.org/xp-forge/inject)
 [![XP Framework Mdodule](https://raw.githubusercontent.com/xp-framework/web/master/static/xp-framework-badge.png)](https://github.com/xp-framework/core)
 [![BSD Licence](https://raw.githubusercontent.com/xp-framework/web/master/static/licence-bsd.png)](https://github.com/xp-framework/core/blob/master/LICENCE.md)
-[![Required PHP 5.4+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_4plus.png)](http://php.net/)
+[![Required PHP 5.5+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_5plus.png)](http://php.net/)
 [![Supports PHP 7.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-7_0plus.png)](http://php.net/)
 [![Supports HHVM 3.4+](https://raw.githubusercontent.com/xp-framework/web/master/static/hhvm-3_4plus.png)](http://hhvm.com/)
 [![Latest Stable Version](https://poser.pugx.org/xp-forge/inject/version.png)](https://packagist.org/packages/xp-forge/inject)
@@ -23,19 +23,23 @@ Values can be bound to the injector by using its `bind()` method. It accepts the
 ```php
 use inject\Injector;
 use inject\Bindings;
+use com\example\Report;
+use com\example\HtmlReport;
+use com\example\Storage;
+use com\example\InFileSystem;
 
 // Manually
 $injector= new Injector();
-$injector->bind('com.example.Report', 'com.example.HtmlReport');
-$injector->bind('com.example.Storage', new InFileSystem('.'));
+$injector->bind(Report::class, HtmlReport::class);
+$injector->bind(Storage::class, new InFileSystem('.'));
 $injector->bind('string', 'Report title', 'title');
 
 // Reusable via Bindings instances
 class ApplicationDefaults extends Bindings {
 
   public function configure($injector) {
-    $injector->bind('com.example.Report', 'com.example.HtmlReport');
-    $injector->bind('com.example.Storage', new InFileSystem('.'));
+    $injector->bind(Report::class, HtmlReport::class);
+    $injector->bind(Storage::class, new InFileSystem('.'));
     $injector->bind('string', 'Report title', 'title');
   }
 }
@@ -50,13 +54,13 @@ Keep in mind: ***"injector.get() is the new 'new'"***. To create objects and per
 ```php
 use inject\Injector;
 
-$injector->bind('com.example.Report', 'com.example.HtmlReport');
+$injector->bind(Report::class, HtmlReport::class);
 
 // Explicit binding: Lookup finds binding to HtmlReport, creates instance.
-$instance= $injector->get('com.example.Report');
+$instance= $injector->get(Report::class);
 
 // Implicit binding: No previous binding, TextReport instantiable, thus created.
-$instance= $injector->get('com.example.TextReport');
+$instance= $injector->get(TextReport::class);
 ```
 
 Manual calls are usually not necessary though, instead you'll use injection:
@@ -123,14 +127,16 @@ If we need control over the lookup, we can bind instances of `Named`:
 
 ```php
 use inject\Injector;
+use inject\Named;
 use inject\InstanceBinding;
+use com\example\Value;
 
 $inject= new Injector();
-$inject->bind('com.example.Value', newinstance('inject.Named', [], [
+$inject->bind(Value::class, newinstance(Named::class, [], [
   'provides' => function($name) { return true; },
   'binding'  => function($name) { return new InstanceBinding(new Value($name)); }
 ]));
 
-$value= $inject->get('com.example.Value', 'default');  // new Value("default")
+$value= $inject->get(Value::class, 'default');  // new Value("default")
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ class ReportWriter extends \lang\Object implements Writer {
 }
 
 $injector= new Injector();
-$report= $injector->get('com.example.ReportWriter');  // *** Storage not bound
+$report= $injector->get(ReportWriter::class);  // *** Storage not bound
 ```
 
 Method and field injection are not supported.

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "~6.0",
-    "php" : ">=5.4.0"
+    "php" : ">=5.5.0"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/test/php/inject/unittest/AnnotatedConstructorTest.class.php
+++ b/src/test/php/inject/unittest/AnnotatedConstructorTest.class.php
@@ -7,99 +7,100 @@ use unittest\TestCase;
 use inject\ProvisionException;
 use inject\unittest\fixture\FileSystem;
 use inject\unittest\fixture\Storage;
+use inject\unittest\fixture\Value;
 
 class AnnotatedConstructorTest extends AnnotationsTest {
 
   #[@test]
   public function with_inject_annotation_and_type() {
-    $this->inject->bind('inject.unittest.fixture.Value', $this->newInstance([
+    $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
       '#[@inject(type= "unittest.TestCase")] __construct' => function($param) { $this->injected= $param; }
     ]));
-    $this->assertEquals($this, $this->inject->get('inject.unittest.fixture.Value')->injected);
+    $this->assertEquals($this, $this->inject->get(Value::class)->injected);
   }
 
   #[@test]
   public function with_inject_annotation_and_restriction() {
-    $this->inject->bind('inject.unittest.fixture.Value', $this->newInstance([
+    $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
       '#[@inject] __construct' => function(TestCase $param) { $this->injected= $param; }
     ]));
-    $this->assertEquals($this, $this->inject->get('inject.unittest.fixture.Value')->injected);
+    $this->assertEquals($this, $this->inject->get(Value::class)->injected);
   }
 
   #[@test]
   public function optional_bound_parameter() {
-    $this->inject->bind('inject.unittest.fixture.Value', $this->newInstance([
+    $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
       '#[@inject] __construct' => function(TestCase $test= null) { $this->injected= $test; }
     ]));
-    $this->assertEquals($this, $this->inject->get('inject.unittest.fixture.Value')->injected);
+    $this->assertEquals($this, $this->inject->get(Value::class)->injected);
   }
 
   #[@test]
   public function optional_unbound_parameter() {
-    $this->inject->bind('inject.unittest.fixture.Value', $this->newInstance([
+    $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
       '#[@inject] __construct' => function(TestCase $test, $verify= true) { $this->injected= [$test, $verify]; }
     ]));
-    $this->assertEquals([$this, true], $this->inject->get('inject.unittest.fixture.Value')->injected);
+    $this->assertEquals([$this, true], $this->inject->get(Value::class)->injected);
   }
 
   #[@test]
   public function with_inject_annotation_and_multiple_parameters() {
-    $this->inject->bind('inject.unittest.fixture.Value', $this->newInstance([
+    $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
       '#[@inject] __construct' => function(TestCase $test, Storage $storage) {
         $this->injected= [$test, $storage];
       }
     ]));
-    $this->assertEquals([$this, new FileSystem()], $this->inject->get('inject.unittest.fixture.Value')->injected);
+    $this->assertEquals([$this, new FileSystem()], $this->inject->get(Value::class)->injected);
   }
 
   #[@test]
   public function with_inject_parameter_annotations() {
-    $this->inject->bind('inject.unittest.fixture.Value', $this->newInstance([
+    $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
       '#[@$test: inject, @$cur: inject(name= "EUR")] __construct' => function(TestCase $test, Currency $cur) {
         $this->injected= [$test, $cur];
       }
     ]));
-    $this->assertEquals([$this, Currency::$EUR], $this->inject->get('inject.unittest.fixture.Value')->injected);
+    $this->assertEquals([$this, Currency::$EUR], $this->inject->get(Value::class)->injected);
   }
 
   #[@test]
   public function with_inject_annotation_and_inject_parameter_annotations() {
-    $this->inject->bind('inject.unittest.fixture.Value', $this->newInstance([
+    $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
       '#[@inject, @$name: inject(name= "name", type= "string")] __construct' => function(TestCase $test, Storage $storage, $name) {
         $this->injected= [$test, $storage, $name];
       }
     ]));
-    $this->assertEquals([$this, new FileSystem(), 'Test'], $this->inject->get('inject.unittest.fixture.Value')->injected);
+    $this->assertEquals([$this, new FileSystem(), 'Test'], $this->inject->get(Value::class)->injected);
   }
 
   #[@test, @expect(class= ProvisionException::class, withMessage= '/Error creating an instance/')]
   public function injecting_unbound_into_constructor_via_method_annotation() {
-    $this->inject->bind('inject.unittest.fixture.Value', $this->newInstance([
+    $this->inject->bind(Value::class, $this->newInstance([
       '#[@inject] __construct' => function(Runnable $param) { /* Empty */ }
     ]));
-    $this->inject->get('inject.unittest.fixture.Value');
+    $this->inject->get(Value::class);
   }
 
   #[@test, @expect(class= ProvisionException::class, withMessage= '/Error creating an instance/')]
   public function injecting_unbound_into_constructor_via_parameter_annotation() {
-    $this->inject->bind('inject.unittest.fixture.Value', $this->newInstance([
+    $this->inject->bind(Value::class, $this->newInstance([
       '#[@$param: inject] __construct' => function(Runnable $param) { /* Empty */ }
     ]));
-    $this->inject->get('inject.unittest.fixture.Value');
+    $this->inject->get(Value::class);
   }
 
   #[@test, @expect(class= ProvisionException::class, withMessage= '/Error creating an instance/')]
   public function throwing_an_exception_from_constructor_raises_ProvisionException() {
-    $this->inject->bind('inject.unittest.fixture.Value', $this->newInstance([
+    $this->inject->bind(Value::class, $this->newInstance([
       '__construct' => function() { throw new IllegalArgumentException('Test'); }
     ]));
-    $this->inject->get('inject.unittest.fixture.Value');
+    $this->inject->get(Value::class);
   }
 }

--- a/src/test/php/inject/unittest/AnnotationsTest.class.php
+++ b/src/test/php/inject/unittest/AnnotationsTest.class.php
@@ -4,19 +4,23 @@ use inject\Injector;
 use unittest\TestCase;
 use util\Currency;
 use lang\ClassLoader;
+use inject\unittest\fixture\Storage;
 use inject\unittest\fixture\FileSystem;
+use inject\unittest\fixture\Value;
 
 abstract class AnnotationsTest extends TestCase {
   protected $inject;
 
   /**
    * Sets up test case and binds this test case
+   *
+   * @return void
    */
   public function setUp() {
     $this->inject= new Injector();
-    $this->inject->bind('unittest.TestCase', $this);
-    $this->inject->bind('inject.unittest.fixture.Storage', new FileSystem());
-    $this->inject->bind('util.Currency', Currency::$EUR, 'EUR');
+    $this->inject->bind(TestCase::class, $this);
+    $this->inject->bind(Storage::class, new FileSystem());
+    $this->inject->bind(Currency::class, Currency::$EUR, 'EUR');
     $this->inject->bind('string', 'Test', 'name');
   }
 
@@ -27,11 +31,6 @@ abstract class AnnotationsTest extends TestCase {
    * @return inject.unittest.fixture.Storage
    */
   protected function newInstance($definition) {
-    return ClassLoader::defineClass(
-      'inject.unittest.fixture.'.$this->name,
-      'inject.unittest.fixture.Value',
-      [],
-      $definition
-    );
+    return ClassLoader::defineClass('inject.unittest.fixture.'.$this->name, Value::class, [], $definition);
   }
 }

--- a/src/test/php/inject/unittest/BindingsTest.class.php
+++ b/src/test/php/inject/unittest/BindingsTest.class.php
@@ -3,6 +3,7 @@
 use inject\Bindings;
 use inject\Injector;
 use inject\unittest\fixture\FileSystem;
+use inject\unittest\fixture\Storage;
 use util\Currency;
 use unittest\TestCase;
 
@@ -13,27 +14,27 @@ class BindingsTest extends TestCase {
    * Initializes bindings
    */
   public function setUp() {
-    $this->bindings= newinstance('inject.Bindings', [], [
-      'configure' => function($inject) { $inject->bind('inject.unittest.fixture.Storage', new FileSystem()); }
+    $this->bindings= newinstance(Bindings::class, [], [
+      'configure' => function($inject) { $inject->bind(Storage::class, new FileSystem()); }
     ]);
   }
 
   #[@test]
   public function can_optionally_be_given_binding() {
     $inject= new Injector($this->bindings);
-    $this->assertInstanceOf('inject.unittest.fixture.FileSystem', $inject->get('inject.unittest.fixture.Storage'));
+    $this->assertInstanceOf(FileSystem::class, $inject->get(Storage::class));
   }
 
   #[@test]
   public function can_optionally_be_given_bindings() {
     $inject= new Injector(
       $this->bindings,
-      newinstance('inject.Bindings', [], [
-        'configure' => function($inject) { $inject->bind('util.Currency', Currency::$EUR, 'EUR'); }
+      newinstance(Bindings::class, [], [
+        'configure' => function($inject) { $inject->bind(Currency::class, Currency::$EUR, 'EUR'); }
       ])
     );
-    $this->assertInstanceOf('inject.unittest.fixture.FileSystem', $inject->get('inject.unittest.fixture.Storage'));
-    $this->assertEquals(Currency::$EUR, $inject->get('util.Currency', 'EUR'));
+    $this->assertInstanceOf(FileSystem::class, $inject->get(Storage::class));
+    $this->assertEquals(Currency::$EUR, $inject->get(Currency::class, 'EUR'));
   }
 
   #[@test]
@@ -46,6 +47,6 @@ class BindingsTest extends TestCase {
   public function add() {
     $inject= new Injector();
     $inject->add($this->bindings);
-    $this->assertInstanceOf('inject.unittest.fixture.FileSystem', $inject->get('inject.unittest.fixture.Storage'));
+    $this->assertInstanceOf(FileSystem::class, $inject->get(Storage::class));
   }
 }

--- a/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
+++ b/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
@@ -5,6 +5,7 @@ use inject\ConfiguredBindings;
 use util\Properties;
 use inject\unittest\fixture\Value;
 use inject\unittest\fixture\FileSystem;
+use inject\unittest\fixture\Storage;
 
 class ConfiguredBindingsTest extends \unittest\TestCase {
 
@@ -23,7 +24,7 @@ class ConfiguredBindingsTest extends \unittest\TestCase {
     $inject= new Injector(new ConfiguredBindings(Properties::fromString('
       inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem
     ')));
-    $this->assertEquals(new FileSystem(), $inject->get('inject.unittest.fixture.Storage'));
+    $this->assertEquals(new FileSystem(), $inject->get(Storage::class));
   }
 
   #[@test]
@@ -31,7 +32,7 @@ class ConfiguredBindingsTest extends \unittest\TestCase {
     $inject= new Injector(new ConfiguredBindings(Properties::fromString('
       inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem("/usr")
     ')));
-    $this->assertEquals(new FileSystem('/usr'), $inject->get('inject.unittest.fixture.Storage'));
+    $this->assertEquals(new FileSystem('/usr'), $inject->get(Storage::class));
   }
 
   #[@test, @values([
@@ -51,7 +52,7 @@ class ConfiguredBindingsTest extends \unittest\TestCase {
     $inject= new Injector(new ConfiguredBindings(Properties::fromString('
       inject.unittest.fixture.Storage[files]=inject.unittest.fixture.FileSystem
     ')));
-    $this->assertEquals(new FileSystem(), $inject->get('inject.unittest.fixture.Storage', 'files'));
+    $this->assertEquals(new FileSystem(), $inject->get(Storage::class, 'files'));
   }
 
   #[@test]
@@ -59,7 +60,7 @@ class ConfiguredBindingsTest extends \unittest\TestCase {
     $inject= new Injector(new ConfiguredBindings(Properties::fromString('
       inject.unittest.fixture.Storage[files]=inject.unittest.fixture.FileSystem("/usr")
     ')));
-    $this->assertEquals(new FileSystem('/usr'), $inject->get('inject.unittest.fixture.Storage', 'files'));
+    $this->assertEquals(new FileSystem('/usr'), $inject->get(Storage::class, 'files'));
   }
 
   #[@test]
@@ -70,7 +71,7 @@ class ConfiguredBindingsTest extends \unittest\TestCase {
     ')));
     $this->assertEquals(
       [new FileSystem('~/.xp'), new FileSystem('/etc/xp')],
-      [$inject->get('inject.unittest.fixture.Storage', 'user'), $inject->get('inject.unittest.fixture.Storage', 'system')]
+      [$inject->get(Storage::class, 'user'), $inject->get(Storage::class, 'system')]
     );
   }
 
@@ -105,6 +106,6 @@ class ConfiguredBindingsTest extends \unittest\TestCase {
       [inject.unittest.fixture]
       '.$line.'
     ')));
-    $this->assertEquals(new FileSystem(), $inject->get('inject.unittest.fixture.Storage'));
+    $this->assertEquals(new FileSystem(), $inject->get(Storage::class));
   }
 }

--- a/src/test/php/inject/unittest/InjectorTest.class.php
+++ b/src/test/php/inject/unittest/InjectorTest.class.php
@@ -8,19 +8,21 @@ use lang\ClassNotFoundException;
 use unittest\TestCase;
 use util\Currency;
 use inject\unittest\fixture\FileSystem;
+use inject\unittest\fixture\Storage;
+use inject\unittest\fixture\AbstractStorage;
 
 class InjectorTest extends TestCase {
 
   /** @return var[][] */
   protected function bindings() {
     $instance= new FileSystem();
-    $name= 'inject.unittest.fixture.Storage';
+    $name= Storage::class;
     return [
-      [$name, XPClass::forName('inject.unittest.fixture.FileSystem')],
-      [$name, 'inject.unittest.fixture.FileSystem'],
+      [$name, XPClass::forName(FileSystem::class)],
+      [$name, FileSystem::class],
       [$name, $instance],
-      [XPClass::forName($name), XPClass::forName('inject.unittest.fixture.FileSystem')],
-      [XPClass::forName($name), 'inject.unittest.fixture.FileSystem'],
+      [XPClass::forName($name), XPClass::forName(FileSystem::class)],
+      [XPClass::forName($name), FileSystem::class],
       [XPClass::forName($name), $instance]
     ];
   }
@@ -45,31 +47,31 @@ class InjectorTest extends TestCase {
   #[@test]
   public function binds_self_per_default() {
     $inject= new Injector();
-    $this->assertEquals($inject, $inject->get('inject.Injector'));
+    $this->assertEquals($inject, $inject->get(Injector::class));
   }
 
   #[@test, @values('bindings')]
   public function get_implementation_bound_to_interface($type, $impl) {
     $inject= new Injector();
     $inject->bind($type, $impl);
-    $this->assertInstanceOf('inject.unittest.fixture.FileSystem', $inject->get($type));
+    $this->assertInstanceOf(FileSystem::class, $inject->get($type));
   }
 
   #[@test]
   public function creates_implicit_binding_when_no_explicit_binding_exists_and_type_is_concrete() {
     $inject= new Injector();
-    $impl= 'inject.unittest.fixture.FileSystem';
+    $impl= FileSystem::class;
     $this->assertInstanceOf($impl, $inject->get($impl));
   }
 
   #[@test]
   public function no_implicit_binding_for_interfaces() {
-    $this->assertNull((new Injector())->get('inject.unittest.fixture.Storage'));
+    $this->assertNull((new Injector())->get(Storage::class));
   }
 
   #[@test]
   public function no_implicit_binding_for_abstract_classes() {
-    $this->assertNull((new Injector())->get('inject.unittest.fixture.AbstractStorage'));
+    $this->assertNull((new Injector())->get(AbstractStorage::class));
   }
 
   #[@test]
@@ -101,38 +103,38 @@ class InjectorTest extends TestCase {
   #[@test, @expect(IllegalArgumentException::class)]
   public function cannot_bind_non_concrete_implementation() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Storage', 'inject.unittest.fixture.AbstractStorage');
+    $inject->bind(Storage::class, AbstractStorage::class);
   }
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function cannot_bind_uncompatible_instance() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Storage', $this);
+    $inject->bind(Storage::class, $this);
   }
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function cannot_bind_uncompatible_class() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Storage', XPClass::forName('unittest.TestCase'));
+    $inject->bind(Storage::class, XPClass::forName(TestCase::class));
   }
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function cannot_bind_uncompatible_class_name() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Storage', 'unittest.TestCase');
+    $inject->bind(Storage::class, TestCase::class);
   }
 
   #[@test, @expect(ClassNotFoundException::class)]
   public function cannot_bind_non_existant_class() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Storage', '@non.existant.class@');
+    $inject->bind(Storage::class, '@non.existant.class@');
   }
 
   #[@test, @values('bindings')]
   public function get_named_implementation_bound_to_interface($type, $impl) {
     $inject= new Injector();
     $inject->bind($type, $impl, 'test');
-    $this->assertInstanceOf('inject.unittest.fixture.FileSystem', $inject->get($type, 'test'));
+    $this->assertInstanceOf(FileSystem::class, $inject->get($type, 'test'));
   }
 
   #[@test, @values('bindings')]

--- a/src/test/php/inject/unittest/MemberInjectionTest.class.php
+++ b/src/test/php/inject/unittest/MemberInjectionTest.class.php
@@ -16,7 +16,7 @@ class MemberInjectionTest extends \unittest\TestCase {
    */
   public function setUp() {
     $this->inject= new Injector();
-    $this->inject->bind('inject.unittest.fixture.Storage', new FileSystem());
+    $this->inject->bind(Storage::class, new FileSystem());
   }
 
   #[@test]
@@ -25,7 +25,7 @@ class MemberInjectionTest extends \unittest\TestCase {
       '#[@inject(type= "inject.unittest.fixture.Storage")] storage' => null
     ]));
 
-    $this->assertInstanceOf('inject.unittest.fixture.Storage', $fixture->storage);
+    $this->assertInstanceOf(Storage::class, $fixture->storage);
   }
 
   #[@test]
@@ -35,7 +35,7 @@ class MemberInjectionTest extends \unittest\TestCase {
       '#[@inject] useStorage' => function(Storage $storage) { $this->storage= $storage; }
     ]));
 
-    $this->assertInstanceOf('inject.unittest.fixture.Storage', $fixture->storage);
+    $this->assertInstanceOf(Storage::class, $fixture->storage);
   }
 
   #[@test]
@@ -45,7 +45,7 @@ class MemberInjectionTest extends \unittest\TestCase {
       '#[@$storage: inject] useStorage' => function(Storage $storage) { $this->storage= $storage; }
     ]));
 
-    $this->assertInstanceOf('inject.unittest.fixture.Storage', $fixture->storage);
+    $this->assertInstanceOf(Storage::class, $fixture->storage);
   }
 
   #[@test]
@@ -55,12 +55,12 @@ class MemberInjectionTest extends \unittest\TestCase {
       '#[@inject(type= "inject.unittest.fixture.Storage")] useStorage' => function($storage) { $this->storage= $storage; }
     ]));
 
-    $this->assertInstanceOf('inject.unittest.fixture.Storage', $fixture->storage);
+    $this->assertInstanceOf(Storage::class, $fixture->storage);
   }
 
   #[@test]
   public function get_does_not_inject_members() {
-    $class= ClassLoader::defineClass('NotInjected', 'lang.Object', ['inject.unittest.fixture.Storage'], [
+    $class= ClassLoader::defineClass('NotInjected', 'lang.Object', [Storage::class], [
       '#[@inject(type= "inject.unittest.fixture.Storage")] storage' => null,
       '#[@inject(type= "inject.unittest.fixture.Storage")] useStorage' => function($storage) {
         throw new IllegalStateException('Should not be reached');

--- a/src/test/php/inject/unittest/NamedTest.class.php
+++ b/src/test/php/inject/unittest/NamedTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace inject\unittest;
 
 use inject\Injector;
+use inject\Named;
 use inject\InstanceBinding;
 use inject\unittest\fixture\Value;
 use lang\Type;
@@ -10,40 +11,40 @@ class NamedTest extends \unittest\TestCase {
   #[@test]
   public function providing_named_values() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Value', newinstance('inject.Named', [], [
+    $inject->bind(Value::class, newinstance(Named::class, [], [
       'provides' => function($name) { return true; },
       'binding'  => function($name) { return new InstanceBinding(new Value($name)); }
     ]));
 
-    $this->assertEquals(new Value('default'), $inject->get('inject.unittest.fixture.Value', 'default'));
+    $this->assertEquals(new Value('default'), $inject->get(Value::class, 'default'));
   }
 
   #[@test]
   public function providing_without_name() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Value', newinstance('inject.Named', [], [
+    $inject->bind(Value::class, newinstance(Named::class, [], [
       'provides' => function($name) { return true; },
       'binding'  => function($name) { return new InstanceBinding(new Value($name)); }
     ]));
 
-    $this->assertEquals(new Value(null), $inject->get('inject.unittest.fixture.Value'));
+    $this->assertEquals(new Value(null), $inject->get(Value::class));
   }
 
   #[@test]
   public function get_returns_null_if_provides_returns_false() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Value', newinstance('inject.Named', [], [
+    $inject->bind(Value::class, newinstance(Named::class, [], [
       'provides' => function($name) { return false; },
       'binding'  => function($name) { throw new IllegalStateException('Should not be reached'); }
     ]));
 
-    $this->assertNull($inject->get('inject.unittest.fixture.Value', 'default'));
+    $this->assertNull($inject->get(Value::class, 'default'));
   }
 
   #[@test]
   public function using_a_provider() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Value', newinstance('inject.Named', [], [
+    $inject->bind(Value::class, newinstance(Named::class, [], [
       'provides' => function($name) { return true; },
       'binding'  => function($name) { return new InstanceBinding(new Value($name)); }
     ]));

--- a/src/test/php/inject/unittest/NewInstanceTest.class.php
+++ b/src/test/php/inject/unittest/NewInstanceTest.class.php
@@ -5,6 +5,7 @@ use unittest\TestCase;
 use util\Currency;
 use lang\ClassLoader;
 use lang\Runnable;
+use inject\unittest\fixture\Storage;
 
 class NewInstanceTest extends TestCase {
 
@@ -18,7 +19,7 @@ class NewInstanceTest extends TestCase {
     return ClassLoader::defineClass(
       'inject.unittest.fixture.'.$this->name,
       'lang.Object',
-      ['inject.unittest.fixture.Storage'],
+      [Storage::class],
       $definition
     );
   }
@@ -26,7 +27,7 @@ class NewInstanceTest extends TestCase {
   #[@test]
   public function newInstance_performs_injection() {
     $inject= new Injector();
-    $inject->bind('unittest.TestCase', $this);
+    $inject->bind(TestCase::class, $this);
     $storage= $this->newStorage([
       'injected' => null,
       '#[@inject] __construct' => function(TestCase $param) { $this->injected= $param; }
@@ -47,7 +48,7 @@ class NewInstanceTest extends TestCase {
   #[@test]
   public function newInstance_performs_partial_injection_with_required_parameter() {
     $inject= new Injector();
-    $inject->bind('unittest.TestCase', $this);
+    $inject->bind(TestCase::class, $this);
     $storage= $this->newStorage([
       'injected' => null,
       '#[@inject] __construct' => function(TestCase $param, $verify) { $this->injected= [$param, $verify]; }
@@ -58,7 +59,7 @@ class NewInstanceTest extends TestCase {
   #[@test]
   public function newInstance_performs_partial_injection_with_optional_parameter() {
     $inject= new Injector();
-    $inject->bind('unittest.TestCase', $this);
+    $inject->bind(TestCase::class, $this);
     $storage= $this->newStorage([
       'injected' => null,
       '#[@inject] __construct' => function(TestCase $param, $verify= true) { $this->injected= [$param, $verify]; }

--- a/src/test/php/inject/unittest/ProvidersTest.class.php
+++ b/src/test/php/inject/unittest/ProvidersTest.class.php
@@ -1,17 +1,19 @@
 <?php namespace inject\unittest;
 
 use inject\Injector;
+use inject\InstanceProvider;
 use inject\TypeProvider;
 use unittest\TestCase;
 use lang\XPClass;
 use inject\unittest\fixture\FileSystem;
+use inject\unittest\fixture\Storage;
 
 class ProvidersTest extends TestCase {
 
   #[@test]
   public function type_provider() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Storage', XPClass::forName('inject.unittest.fixture.FileSystem'));
+    $inject->bind(Storage::class, XPClass::forName(FileSystem::class));
     $this->assertInstanceOf(
       'inject.TypeProvider',
       $inject->get('inject.Provider<inject.unittest.fixture.Storage>')
@@ -21,9 +23,9 @@ class ProvidersTest extends TestCase {
   #[@test]
   public function type_provider_get() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Storage', XPClass::forName('inject.unittest.fixture.FileSystem'));
+    $inject->bind(Storage::class, XPClass::forName(FileSystem::class));
     $this->assertInstanceOf(
-      'inject.unittest.fixture.FileSystem',
+      FileSystem::class,
       $inject->get('inject.Provider<inject.unittest.fixture.Storage>')->get()
     );
   }
@@ -31,28 +33,28 @@ class ProvidersTest extends TestCase {
   #[@test]
   public function type_provider_bound_to_type_provider() {
     $inject= new Injector();
-    $provider= new TypeProvider(XPClass::forName('inject.unittest.fixture.FileSystem'), $inject);
-    $inject->bind('inject.unittest.fixture.Storage', $provider);
+    $provider= new TypeProvider(XPClass::forName(FileSystem::class), $inject);
+    $inject->bind(Storage::class, $provider);
     $this->assertEquals($provider, $inject->get('inject.Provider<inject.unittest.fixture.Storage>'));
   }
 
   #[@test]
   public function type_bound_to_type_provider() {
     $inject= new Injector();
-    $provider= new TypeProvider(XPClass::forName('inject.unittest.fixture.FileSystem'), $inject);
-    $inject->bind('inject.unittest.fixture.Storage', $provider);
+    $provider= new TypeProvider(XPClass::forName(FileSystem::class), $inject);
+    $inject->bind(Storage::class, $provider);
     $this->assertInstanceOf(
-      'inject.unittest.fixture.FileSystem',
-      $inject->get('inject.unittest.fixture.Storage')
+      FileSystem::class,
+      $inject->get(Storage::class)
     );
   }
 
   #[@test]
   public function instance_provider() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Storage', new FileSystem());
+    $inject->bind(Storage::class, new FileSystem());
     $this->assertInstanceOf(
-      'inject.InstanceProvider',
+      InstanceProvider::class,
       $inject->get('inject.Provider<inject.unittest.fixture.Storage>')
     );
   }
@@ -60,9 +62,9 @@ class ProvidersTest extends TestCase {
   #[@test]
   public function instance_provider_get() {
     $inject= new Injector();
-    $inject->bind('inject.unittest.fixture.Storage', new FileSystem());
+    $inject->bind(Storage::class, new FileSystem());
     $this->assertInstanceOf(
-      'inject.unittest.fixture.FileSystem',
+      FileSystem::class,
       $inject->get('inject.Provider<inject.unittest.fixture.Storage>')->get()
     );
   }


### PR DESCRIPTION
This pull request drops PHP 5.4 support by starting to rely on `T::class` and bumps the minimum PHP version required to 5.5.

*Note: As the main source is not touched, unofficial PHP 5.4 support is still available though not tested with Travis-CI. This is consistent with [xp core 6.5.0](https://github.com/xp-framework/core/releases/tag/v6.5.0).*