### PR TITLE
Support instances without lang.Object as base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ php:
   - hhvm
   - nightly
 
+matrix:
+  allow_failures:
+    - php: nightly
+
 before_script:
   - wget 'https://github.com/xp-framework/xp-runners/releases/download/v6.3.0/setup' -O - | php
   - composer install --prefer-dist

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ Injection is performed by looking at a type's constructor. If it's annotated wit
 
 ```php
 // Single parameter
-class ReportImpl extends \lang\Object implements Report {
+class ReportImpl implements Report {
 
   #[@inject]
   public function __construct(ReportWriter $writer) { ... }
 }
 
 // Multiple parameters
-class ReportImpl extends \lang\Object implements Report {
+class ReportImpl implements Report {
 
   #[@inject]
   public function __construct(ReportWriter $writer, Format $format) { ... }
@@ -88,7 +88,7 @@ class ReportImpl extends \lang\Object implements Report {
 You can supply name and type by using parameter annotations:
 
 ```php
-class ReportImpl extends \lang\Object implements Report {
+class ReportImpl implements Report {
 
   #[@inject, @$title: inject(type= 'string', name= 'title')]
   public function __construct(ReportWriter $writer, Format $format, $title) { ... }
@@ -98,7 +98,7 @@ class ReportImpl extends \lang\Object implements Report {
 When a required parameter is encountered and there is no bound value for this parameter, an `inject.ProvisionException` is raised.
 
 ```php
-class ReportWriter extends \lang\Object implements Writer {
+class ReportWriter implements Writer {
 
   #[@inject]
   public function __construct(Storage $storage) { ... }

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -26,7 +26,7 @@ class Injector extends \lang\Object {
    * @param  inject.Bindings... $initial
    */
   public function __construct() {
-    $this->bind($this->getClass(), $this);
+    $this->bind(typeof($this), $this);
     foreach (func_get_args() as $bindings) {
       $this->add($bindings);
     }
@@ -43,7 +43,7 @@ class Injector extends \lang\Object {
       return new ClassBinding($impl, $t);
     } else if (self::$PROVIDER->isInstance($impl) || $impl instanceof Provider) {
       return new ProviderBinding($impl);
-    } else if ($impl instanceof Generic) {
+    } else if (is_object($impl)) {
       return new InstanceBinding($impl, $t);
     } else {
       return new ClassBinding(XPClass::forName((string)$impl), $t);
@@ -232,12 +232,12 @@ class Injector extends \lang\Object {
   /**
    * Inject members of an instance
    *
-   * @param   lang.Generic $instance
-   * @return  lang.Generic
+   * @param   var $instance A value object
+   * @return  var
    * @throws  inject.ProvisionException
    */
-  public function into(Generic $instance) {
-    $class= $instance->getClass();
+  public function into($instance) {
+    $class= cast(typeof($instance), 'lang.XPClass');
 
     foreach ($class->getFields() as $field) {
       if (!$field->hasAnnotation('inject')) continue;

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -2,7 +2,6 @@
 
 use lang\Type;
 use lang\XPClass;
-use lang\Generic;
 use lang\Throwable;
 use lang\IllegalArgumentException;
 use lang\reflect\TargetInvocationException;
@@ -211,7 +210,7 @@ class Injector extends \lang\Object {
    *
    * @param   lang.XPClass $class
    * @param   [:var] $named Named arguments
-   * @return  lang.Generic
+   * @return  var
    * @throws  inject.ProvisionException
    */
   public function newInstance(XPClass $class, $named= []) {

--- a/src/test/php/inject/unittest/fixture/Value.class.php
+++ b/src/test/php/inject/unittest/fixture/Value.class.php
@@ -2,19 +2,25 @@
 
 use util\Objects;
 
-class Value extends \lang\Object {
+class Value implements \lang\Value {
   private $backing;
 
   /** @param var $initial */
   public function __construct($initial) { $this->backing= $initial; }
 
+  /** @return string */
+  public function hashCode() { return 'V@'.Objects::hashOf($this->backing); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'('.Objects::stringOf($this->backing).')'; }
+
   /**
    * Returns whether another value is equal to this
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && Objects::equal($this->backing, $cmp->backing);
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->backing, $value->backing) : 1;
   }
 }


### PR DESCRIPTION
...e.g. ones implementing `lang.Value` (see xp-framework/rfc#297), native PHP objects and those without any "instanceof" relation to one another.

This feature would bump the version number to **1.1.0**