### PR TITLE
Add support for inheritance via property file section

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,18 +70,10 @@ Injection
 Injection is performed by looking at a type's constructor. If it's annotated with an `@inject` annotation, bound values will be passed according to the given type hint.
 
 ```php
-// Single parameter
 class ReportImpl implements Report {
 
   #[@inject]
   public function __construct(ReportWriter $writer) { ... }
-}
-
-// Multiple parameters
-class ReportImpl implements Report {
-
-  #[@inject]
-  public function __construct(ReportWriter $writer, Format $format) { ... }
 }
 ```
 
@@ -109,6 +101,24 @@ $report= $injector->get(ReportWriter::class);  // *** Storage not bound
 ```
 
 Method and field injection are not supported.
+
+Configuration
+-------------
+As seen above, bindings can be used instead of manually performing the wiring. You might want to configure some of your app's settings externally instead of harcoding them. Use the `inject.ConfiguredBindings` class for this:
+
+```php
+$injector= new Injector(
+  new ApplicationDefaults(),
+  new ConfiguredBindings(new Properties('etc/app.ini'))
+);
+```
+
+The syntax for these INI files is simple:
+
+```ini
+scriptlet.Session=com.example.session.FileSystem("/tmp")
+string[name]="Application"
+```
 
 Providers
 ---------

--- a/src/main/php/inject/ConfiguredBindings.class.php
+++ b/src/main/php/inject/ConfiguredBindings.class.php
@@ -14,7 +14,8 @@ use lang\Type;
  * scriptlet.Session=com.example.session.MemCache("tcp://localhost:11211")
  * ```
  *
- * @test    xp://inject.unittest.ConfiguredBindingsTest
+ * @see   https://github.com/xp-forge/inject/pull/10
+ * @test  xp://inject.unittest.ConfiguredBindingsTest
  */
 class ConfiguredBindings extends Bindings {
   private static $PRIMITIVES= [
@@ -28,8 +29,10 @@ class ConfiguredBindings extends Bindings {
   private $section= null;
 
   /**
-   * Creates new bindings from a given properties instance, reading the
-   * bindings only from a given section.
+   * Creates new bindings from a given properties instance. If an optional
+   * section identifier is given, bindings are created from both the global
+   * section *and* the given one - the latter overwriting bindings from the
+   * first (and inheriting ones it doesn't explicitely define).
    *
    * @param  util.PropertyAccess|string $properties
    * @param  string $section

--- a/src/main/php/inject/ConfiguredBindings.class.php
+++ b/src/main/php/inject/ConfiguredBindings.class.php
@@ -9,9 +9,35 @@ use lang\Type;
 /**
  * Bindings from a properties file
  *
+ * ## Basic property file
+ * The bindings are written as key/value pairs. Constructor arguments
+ * are denoted inside braces.
+ *
  * ```ini
  * scriptlet.Session=com.example.session.FileSystem
  * scriptlet.Session=com.example.session.MemCache("tcp://localhost:11211")
+ * ```
+ *
+ * ## Imports
+ * One ore more `use` keys can be used to achieve imports.
+ *
+ * ```ini
+ * use[]=com.example.session
+ *
+ * scriptlet.Session=FileSystem
+ * ```
+ *
+ * ## Inheritance
+ * If created with the optional "section" argument, bindings are created
+ * from both the global section *and* the given one. The latter overwrites
+ * bindings from the first and inherits ones it doesn't explicitely define.
+ *
+ * ```ini
+ * string[name]="Sync"
+ * com.example.Monitoring=com.example.monitoring.Icinga
+ *
+ * [add]
+ * string[name]="Add users"
  * ```
  *
  * @see   https://github.com/xp-forge/inject/pull/10
@@ -29,13 +55,10 @@ class ConfiguredBindings extends Bindings {
   private $section= null;
 
   /**
-   * Creates new bindings from a given properties instance. If an optional
-   * section identifier is given, bindings are created from both the global
-   * section *and* the given one - the latter overwriting bindings from the
-   * first (and inheriting ones it doesn't explicitely define).
+   * Creates new bindings from a given properties instance.
    *
    * @param  util.PropertyAccess|string $properties
-   * @param  string $section
+   * @param  string $section Optional section
    */
   public function __construct($properties, $section= null) {
     if ($properties instanceof PropertyAccess) {

--- a/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
+++ b/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
@@ -117,11 +117,54 @@ class ConfiguredBindingsTest extends \unittest\TestCase {
   #  'inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem',
   #  'inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem()'
   #])]
-  public function uses_propertyfile_sections_as_namespace($line) {
+  public function namespace_import_via_use($line) {
     $inject= new Injector(new ConfiguredBindings(Properties::fromString('
-      [inject.unittest.fixture]
+      use[]=inject.unittest.fixture
       '.$line.'
     ')));
     $this->assertEquals(new FileSystem(), $inject->get(Storage::class));
+  }
+
+  #[@test]
+  public function use_section() {
+    $prop= Properties::fromString('
+      [one]
+      inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem()
+    ');
+    $inject= new Injector(new ConfiguredBindings($prop, 'one'));
+    $this->assertEquals(new FileSystem(), $inject->get(Storage::class));
+  }
+
+  #[@test]
+  public function use_different_section() {
+    $prop= Properties::fromString('
+      [one]
+      inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem()
+    ');
+    $inject= new Injector(new ConfiguredBindings($prop, 'two'));
+    $this->assertNull($inject->get(Storage::class));
+  }
+
+  #[@test]
+  public function inheriting_binding_from_defaults() {
+    $prop= Properties::fromString('
+      inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem()
+
+      [one]
+   ');
+    $inject= new Injector(new ConfiguredBindings($prop, 'one'));
+    $this->assertEquals(new FileSystem(), $inject->get(Storage::class));
+  }
+
+  #[@test]
+  public function overwriting_binding_from_defaults() {
+    $prop= Properties::fromString('
+      inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem()
+
+      [one]
+      inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem("/usr/local")
+   ');
+    $inject= new Injector(new ConfiguredBindings($prop, 'one'));
+    $this->assertEquals(new FileSystem('/usr/local'), $inject->get(Storage::class));
   }
 }


### PR DESCRIPTION
## Example

```ini
string[name]="Sync"
com.example.Monitoring=com.example.monitoring.Icinga

[add]
string[name]="Add Users"
```

When ConfiguredBindings is instantiated with "add" as optional constructor argument, bindings are created from the global **and** the "add" section, with the latter overwriting the defaults (here: the named string binding) and inheriting whatever it does not define explicitely (here: the monitoring binding).

## ⚠️ Warning
This is a BC break as the ini sections where previously used as namespace import statements (this was undocumented, but still!). This has been changed to a syntax more resembling PHP:

```ini
use[]=com.example
use[]=com.example.monitoring

Monitoring=Icinga
```

Therefore the next release would be **2.0.0**