### PR TITLE
Add support for type unions

### DIFF
--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -2,6 +2,7 @@
 
 use lang\Type;
 use lang\XPClass;
+use lang\TypeUnion;
 use lang\Throwable;
 use lang\IllegalArgumentException;
 use lang\reflect\TargetInvocationException;
@@ -94,7 +95,11 @@ class Injector extends \lang\Object {
   public function get($type, $name= null) {
     $t= $type instanceof Type ? $type : Type::forName($type);
 
-    if (self::$PROVIDER->isAssignableFrom($t)) {
+    if ($t instanceof TypeUnion) {
+      foreach ($t->types() as $type) {
+        if ($instance= $this->get($type, $name)) return $instance;
+      }
+    } else if (self::$PROVIDER->isAssignableFrom($t)) {
       $literal= $t->genericArguments()[0]->literal();
       if (isset($this->bindings[$literal][$name])) {
         return $this->bindings[$literal][$name]->provider($this);

--- a/src/test/php/inject/unittest/InjectorTest.class.php
+++ b/src/test/php/inject/unittest/InjectorTest.class.php
@@ -149,4 +149,29 @@ class InjectorTest extends TestCase {
     $inject->bind($type, $impl, 'test');
     $this->assertNull($inject->get($type, 'another-name-than-the-one-bound'));
   }
+
+  #[@test]
+  public function get_given_a_typeunion_searches_all_types() {
+    $fs= new FileSystem('/usr');
+    $inject= new Injector();
+    $inject->bind(FileSystem::class, $fs);
+    $this->assertEquals($fs, $inject->get('string|inject.unittest.fixture.FileSystem'));
+  }
+
+  #[@test]
+  public function get_given_a_typeunion_searches_all_named_types() {
+    $path= '/usr';
+    $inject= new Injector();
+    $inject->bind('string', $path, 'path');
+    $this->assertEquals($path, $inject->get('string|inject.unittest.fixture.FileSystem', 'path'));
+  }
+
+  #[@test]
+  public function get_given_a_typeunion_searches_all_named_types_and_uses_first() {
+    $path= '/usr';
+    $inject= new Injector();
+    $inject->bind('string', $path, 'path');
+    $inject->bind(FileSystem::class, new FileSystem('/usr'));
+    $this->assertEquals($path, $inject->get('string|inject.unittest.fixture.FileSystem', 'path'));
+  }
 }


### PR DESCRIPTION
Example:
```php
class Api {

  /** @param string|peer.URL $endpoint */
  #[@inject(name= 'com.example.api.url')]
  public function __construct($endpoint) { ... }

}
```

When injection is performed, the injector first searches for a string and then for a peer.URL bound by the name `com.example.api.url`