### PR TITLE
Array binding

### DIFF
--- a/src/main/php/inject/ArrayBinding.class.php
+++ b/src/main/php/inject/ArrayBinding.class.php
@@ -3,15 +3,11 @@
 use lang\IllegalArgumentException;
 use lang\XPClass;
 use lang\Type;
+use lang\ArrayType;
 
 class ArrayBinding extends \lang\Object implements Binding {
-  private static $PROVIDER;
   private $type;
   private $binding= [];
-
-  static function __static() {
-    self::$PROVIDER= Type::forName('inject.Provider<?>');
-  }
 
   /**
    * Creates a new instance binding
@@ -20,19 +16,11 @@ class ArrayBinding extends \lang\Object implements Binding {
    * @param  lang.ArrayType $type
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($binding, $type) {
+  public function __construct($binding, ArrayType $type) {
     $this->type= $type;
-    $component= $this->type->componentType();
+    $component= $type->componentType();
     foreach ($binding as $impl) {
-      if ($impl instanceof XPClass) {
-        $this->binding[]= new ClassBinding($impl, $component);
-      } else if (self::$PROVIDER->isInstance($impl) || $impl instanceof Provider) {
-        $this->binding[]= new ProviderBinding($impl);
-      } else if (is_object($impl)) {
-        $this->binding[]= new InstanceBinding($impl, $component);
-      } else {
-        $this->binding[]= new ClassBinding(XPClass::forName((string)$impl), $component);
-      }
+      $this->binding[]= Injector::asBinding($component, $impl);
     }
   }
 
@@ -43,7 +31,7 @@ class ArrayBinding extends \lang\Object implements Binding {
    * @param  inject.Provider<?>
    */
   public function provider($injector) {
-    //return new TypeProvider($this->class, $injector);
+    return new ResolvingProvider($this, $injector);
   }
 
   /**

--- a/src/main/php/inject/ArrayBinding.class.php
+++ b/src/main/php/inject/ArrayBinding.class.php
@@ -16,7 +16,11 @@ class ArrayBinding extends \lang\Object implements Binding {
    * @param  lang.ArrayType $type
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($binding, ArrayType $type) {
+  public function __construct($binding, $type) {
+    if (!($type instanceof ArrayType)) {
+      throw new IllegalArgumentException('Cannot bind an array to a non-array type');
+    }
+
     $this->type= $type;
     $component= $type->componentType();
     foreach ($binding as $impl) {

--- a/src/main/php/inject/ArrayBinding.class.php
+++ b/src/main/php/inject/ArrayBinding.class.php
@@ -1,0 +1,62 @@
+<?php namespace inject;
+
+use lang\IllegalArgumentException;
+use lang\XPClass;
+use lang\Type;
+
+class ArrayBinding extends \lang\Object implements Binding {
+  private static $PROVIDER;
+  private $type;
+  private $binding= [];
+
+  static function __static() {
+    self::$PROVIDER= Type::forName('inject.Provider<?>');
+  }
+
+  /**
+   * Creates a new instance binding
+   *
+   * @param  var[] $binding
+   * @param  lang.ArrayType $type
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct($binding, $type) {
+    $this->type= $type;
+    $component= $this->type->componentType();
+    foreach ($binding as $impl) {
+      if ($impl instanceof XPClass) {
+        $this->binding[]= new ClassBinding($impl, $component);
+      } else if (self::$PROVIDER->isInstance($impl) || $impl instanceof Provider) {
+        $this->binding[]= new ProviderBinding($impl);
+      } else if (is_object($impl)) {
+        $this->binding[]= new InstanceBinding($impl, $component);
+      } else {
+        $this->binding[]= new ClassBinding(XPClass::forName((string)$impl), $component);
+      }
+    }
+  }
+
+  /**
+   * Returns a provider for this binding
+   *
+   * @param  inject.Injector $injector
+   * @param  inject.Provider<?>
+   */
+  public function provider($injector) {
+    //return new TypeProvider($this->class, $injector);
+  }
+
+  /**
+   * Resolves this binding and returns the instance
+   *
+   * @param  inject.Injector $injector
+   * @param  var
+   */
+  public function resolve($injector) {
+    $r= [];
+    foreach ($this->binding as $binding) {
+      $r[]= $binding->resolve($injector); 
+    }
+    return $r;
+  }
+}

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -2,7 +2,6 @@
 
 use lang\Type;
 use lang\XPClass;
-use lang\ArrayType;
 use lang\TypeUnion;
 use lang\Primitive;
 use lang\Throwable;
@@ -40,7 +39,7 @@ class Injector extends \lang\Object {
    * @param  lang.Type $t
    * @param  var $impl
    */
-  protected function asBinding($t, $impl) {
+  public static function asBinding($t, $impl) {
     if ($impl instanceof XPClass) {
       return new ClassBinding($impl, $t);
     } else if (self::$PROVIDER->isInstance($impl) || $impl instanceof Provider) {
@@ -85,7 +84,7 @@ class Injector extends \lang\Object {
       }
       $this->bindings[$t->literal()][$name]= new InstanceBinding($impl, $t);
     } else {
-      $this->bindings[$t->literal()][$name]= $this->asBinding($t, $impl);
+      $this->bindings[$t->literal()][$name]= self::asBinding($t, $impl);
     }
     return $this;
   }

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -2,7 +2,9 @@
 
 use lang\Type;
 use lang\XPClass;
+use lang\ArrayType;
 use lang\TypeUnion;
+use lang\Primitive;
 use lang\Throwable;
 use lang\IllegalArgumentException;
 use lang\reflect\TargetInvocationException;
@@ -35,7 +37,7 @@ class Injector extends \lang\Object {
   /**
    * Returns a binding
    *
-   * @param  lang.XPClass $t
+   * @param  lang.Type $t
    * @param  var $impl
    */
   protected function asBinding($t, $impl) {
@@ -45,6 +47,8 @@ class Injector extends \lang\Object {
       return new ProviderBinding($impl);
     } else if (is_object($impl)) {
       return new InstanceBinding($impl, $t);
+    } else if (is_array($impl)) {
+      return new ArrayBinding($impl, $t);
     } else {
       return new ClassBinding(XPClass::forName((string)$impl), $t);
     }
@@ -75,12 +79,13 @@ class Injector extends \lang\Object {
 
     if ($impl instanceof Named) {
       $this->bindings[$t->literal()]= $impl;
-    } else if ($t instanceof XPClass) {
-      $this->bindings[$t->literal()][$name]= $this->asBinding($t, $impl);
-    } else if (null === $name) {
-      throw new IllegalArgumentException('Cannot bind non-class type '.$t.' without a name');
-    } else {
+    } else if ($t instanceof Primitive) {
+      if (null === $name) {
+        throw new IllegalArgumentException('Cannot bind primitive type '.$t.' without a name');
+      }
       $this->bindings[$t->literal()][$name]= new InstanceBinding($impl, $t);
+    } else {
+      $this->bindings[$t->literal()][$name]= $this->asBinding($t, $impl);
     }
     return $this;
   }

--- a/src/main/php/inject/ResolvingProvider.class.php
+++ b/src/main/php/inject/ResolvingProvider.class.php
@@ -1,0 +1,20 @@
+<?php namespace inject;
+
+#[@generic(implements= ['var'])]
+class ResolvingProvider extends \lang\Object implements Provider {
+  private $binding, $injector;
+
+  /**
+   * Creates a new provider which resolves a binding
+   *
+   * @param  inject.Binding $binding
+   * @param  inject.Injector $injector
+   */
+  public function __construct($binding, $injector) {
+    $this->binding= $binding;
+    $this->injector= $injector;
+  }
+
+  /** @return var */
+  public function get() { return $this->binding->resolve($this->injector); }
+}

--- a/src/test/php/inject/unittest/InjectorTest.class.php
+++ b/src/test/php/inject/unittest/InjectorTest.class.php
@@ -8,6 +8,7 @@ use lang\ClassNotFoundException;
 use unittest\TestCase;
 use util\Currency;
 use inject\unittest\fixture\FileSystem;
+use inject\unittest\fixture\InMemory;
 use inject\unittest\fixture\Storage;
 use inject\unittest\fixture\AbstractStorage;
 
@@ -24,6 +25,15 @@ class InjectorTest extends TestCase {
       [XPClass::forName($name), XPClass::forName(FileSystem::class)],
       [XPClass::forName($name), FileSystem::class],
       [XPClass::forName($name), $instance]
+    ];
+  }
+
+  /** @return var[][] */
+  protected function storages() {
+    return [
+      [[XPClass::forName(FileSystem::class), XPClass::forName(InMemory::class)]],
+      [[FileSystem::class, InMemory::class]],
+      [[new FileSystem(), new InMemory()]]
     ];
   }
 
@@ -55,6 +65,13 @@ class InjectorTest extends TestCase {
     $inject= new Injector();
     $inject->bind($type, $impl);
     $this->assertInstanceOf(FileSystem::class, $inject->get($type));
+  }
+
+  #[@test, @values('storages')]
+  public function bind_array($impl) {
+    $inject= new Injector();
+    $inject->bind('inject.unittest.fixture.Storage[]', $impl);
+    $this->assertEquals([new FileSystem(), new InMemory()], $inject->get('inject.unittest.fixture.Storage[]'));
   }
 
   #[@test]

--- a/src/test/php/inject/unittest/InjectorTest.class.php
+++ b/src/test/php/inject/unittest/InjectorTest.class.php
@@ -147,6 +147,18 @@ class InjectorTest extends TestCase {
     $inject->bind(Storage::class, '@non.existant.class@');
   }
 
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function cannot_bind_array_type_to_non_array() {
+    $inject= new Injector();
+    $inject->bind('inject.unittest.fixture.Storage[]', Storage::class);
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function cannot_bind_non_array_type_to_array() {
+    $inject= new Injector();
+    $inject->bind('inject.unittest.fixture.Storage', [Storage::class]);
+  }
+
   #[@test, @values('bindings')]
   public function get_named_implementation_bound_to_interface($type, $impl) {
     $inject= new Injector();

--- a/src/test/php/inject/unittest/fixture/InMemory.class.php
+++ b/src/test/php/inject/unittest/fixture/InMemory.class.php
@@ -1,0 +1,5 @@
+<?php namespace inject\unittest\fixture;
+
+class InMemory implements Storage {
+
+}


### PR DESCRIPTION
This pull request adds the ability to bind arrays.

## Example
Imagine we have a monitoring infrastructure and want to write monitoring information to more than one sink.

```
interface Monitoring
|- class Icinga implements Monitoring
`- class UpdateStatusWebsite implements Monitoring
```

Next, we want to define a composite to emit monitoring events to both sinks. We define it as follows:

```php
class ToAllOf implements Monitoring {
  private $sinks;

  /**
   * Constructor
   *
   * @param  com.example.monitoring.Monitoring[] $sinks
   */
  #[@inject]
  public function __construct($sinks) {
    $this->sinks= $sinks;
  }

  // ...
}
```

Unfortunately, binding an array is currently not supported and will yield an error. 

With this pull request, the binding code can be written as follows:

```php
$inject->bind('com.example.monitoring.Monitoring[]', [Icinga::class, UpdateStatusWebsite::class]);
$inject->bind('com.example.monitoring.Monitoring', ToAllOf::class);
```

Inspired by https://github.com/stubbles/stubbles-ioc/blob/master/docs/list_bindings.md