### PR TITLE
Make `@inject` annotation optional

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ Dependency injection for the XP Framework change log
 
 ## ?.?.? / ????-??-??
 
+* Made `@inject` annotation optional, now only needs to be supplied for
+  named bindings.
+  (@thekid)
+
 ## 4.0.0 / 2017-06-16
 
 * Added forward compatibility with XP 9.0.0 - @thekid

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $injector= new Injector(new ApplicationDefaults());
 
 Instance creation
 -----------------
-Keep in mind: ***"injector.get() is the new 'new'"***. To create objects and perform injection, use the Injector's get() method instead of using the `new` keyword or factories.
+Keep in mind: **"injector.get() is the new 'new'"**. To create objects and perform injection, use the Injector's get() method instead of using the `new` keyword or factories.
 
 ```php
 use inject\Injector;
@@ -67,12 +67,11 @@ Manual calls are usually not necessary though, instead you'll use injection:
 
 Injection
 ---------
-Injection is performed by looking at a type's constructor. If it's annotated with an `@inject` annotation, bound values will be passed according to the given type hint.
+Injection is performed by looking at a type's constructor. Bound values will be passed according to the given type hint.
 
 ```php
 class ReportImpl implements Report {
 
-  #[@inject]
   public function __construct(ReportWriter $writer) { ... }
 }
 ```
@@ -82,7 +81,7 @@ You can supply name and type by using parameter annotations:
 ```php
 class ReportImpl implements Report {
 
-  #[@inject, @$title: inject(type= 'string', name= 'title')]
+  #[@$title: inject(type= 'string', name= 'title')]
   public function __construct(ReportWriter $writer, Format $format, $title) { ... }
 }
 ```
@@ -92,7 +91,6 @@ When a required parameter is encountered and there is no bound value for this pa
 ```php
 class ReportWriter implements Writer {
 
-  #[@inject]
   public function __construct(Storage $storage) { ... }
 }
 

--- a/src/test/php/inject/unittest/AnnotatedConstructorTest.class.php
+++ b/src/test/php/inject/unittest/AnnotatedConstructorTest.class.php
@@ -103,4 +103,24 @@ class AnnotatedConstructorTest extends AnnotationsTest {
     ]));
     $this->inject->get(Value::class);
   }
+
+  #[@test]
+  public function annotation_is_optional_single_parameter() {
+    $this->inject->bind(Value::class, $this->newInstance([
+      'injected' => null,
+      '__construct' => function(TestCase $test) { $this->injected= $test; }
+    ]));
+    $this->assertEquals($this, $this->inject->get(Value::class)->injected);
+  }
+
+  #[@test]
+  public function annotation_is_optional_multiple_parameters() {
+    $this->inject->bind(Value::class, $this->newInstance([
+      'injected' => null,
+      '__construct' => function(TestCase $test, Storage $storage) {
+        $this->injected= [$test, $storage];
+      }
+    ]));
+    $this->assertEquals([$this, new FileSystem()], $this->inject->get(Value::class)->injected);
+  }
 }

--- a/src/test/php/inject/unittest/NewInstanceTest.class.php
+++ b/src/test/php/inject/unittest/NewInstanceTest.class.php
@@ -95,7 +95,7 @@ class NewInstanceTest extends TestCase {
     $this->newInstance($inject, $storage);
   }
 
-  #[@test, @expect(class= ProvisionException::class, withMessage= '/Unknown injection type string named "endpoint"/')]
+  #[@test, @expect(class= ProvisionException::class, withMessage= '/No bound value for type string named "endpoint"/')]
   public function newInstance_throws_when_value_for_required_parameter_not_found() {
     $inject= new Injector();
     $storage= $this->newStorage([

--- a/src/test/php/inject/unittest/NewInstanceTest.class.php
+++ b/src/test/php/inject/unittest/NewInstanceTest.class.php
@@ -20,7 +20,7 @@ class NewInstanceTest extends TestCase {
   protected function newStorage($definition) {
     return ClassLoader::defineClass(
       'inject.unittest.fixture.'.$this->name,
-      'lang.Object',
+      'inject.unittest.fixture.Fixture',
       [Storage::class],
       $definition
     );

--- a/src/test/php/inject/unittest/fixture/Fixture.class.php
+++ b/src/test/php/inject/unittest/fixture/Fixture.class.php
@@ -1,0 +1,5 @@
+<?php namespace inject\unittest\fixture;
+
+abstract class Fixture {
+
+}


### PR DESCRIPTION
Now only needs to be supplied for named bindings.