### PR TITLE
Add support for arrays and maps as constructor arguments

### DIFF
--- a/src/main/php/inject/ConfiguredBindings.class.php
+++ b/src/main/php/inject/ConfiguredBindings.class.php
@@ -1,10 +1,10 @@
 <?php namespace inject;
 
-use util\PropertyAccess;
-use util\Properties;
 use lang\ClassLoader;
 use lang\ClassNotFoundException;
 use lang\Type;
+use util\Properties;
+use util\PropertyAccess;
 
 /**
  * Bindings from a properties file
@@ -90,42 +90,6 @@ class ConfiguredBindings extends Bindings {
   }
 
   /**
-   * Parse arguments from a string. Supports strings, booleans, null, and numbers.
-   *
-   * @param  string $input
-   * @return var[]
-   */
-  private function argumentsIn($input) {
-    if ('' === $input) return [];
-
-    $arguments= [];
-    for ($o= 0, $l= strlen($input); $o < $l; $o+= $p) {
-      if ('"' === $input{$o} || "'" === $input{$o}) {
-        $s= $o + 1;
-        $str= '';
-        do {
-          $p= strcspn($input, $input{$o}, $s);
-          if ('\\' === $input{$s + $p - 1}) {
-            $str.= substr($input, $s, $p - 1).$input{$o};
-            $s+= $p + 1;
-            continue;
-          } else {
-            $str.= substr($input, $s, $p);
-            $s+= $p + 1;
-            break;
-          }
-        } while ($s < $l);
-        $arguments[]= $str;
-        $p+= $s;
-      } else {
-        $p= strcspn($input, ',', $o);
-        $arguments[]= $this->valueIn(substr($input, $o, $p));
-      }
-    }
-    return $arguments;
-  }
-
-  /**
    * Resolves a name
    *
    * @param  lang.ClassLoader $cl
@@ -158,7 +122,7 @@ class ConfiguredBindings extends Bindings {
     } else {
       $class= $this->resolveType($cl, $namespaces, substr($input, 0, $p));
       if ($class->hasConstructor()) {
-        $arguments= $this->argumentsIn(substr($input, $p + 1, -1));
+        $arguments= eval('return ['.substr($input, $p + 1, -1).'];');
         return $class->getConstructor()->newInstance($arguments);
       } else {
         return $class->newInstance();

--- a/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
+++ b/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
@@ -2,6 +2,7 @@
 
 use inject\ConfiguredBindings;
 use inject\Injector;
+use inject\unittest\fixture\Database;
 use inject\unittest\fixture\FileSystem;
 use inject\unittest\fixture\InMemory;
 use inject\unittest\fixture\Storage;
@@ -98,6 +99,22 @@ class ConfiguredBindingsTest extends \unittest\TestCase {
       [new FileSystem('~/.xp'), new FileSystem('/etc/xp')],
       [$inject->get(Storage::class, 'user'), $inject->get(Storage::class, 'system')]
     );
+  }
+
+  #[@test]
+  public function two_arguments() {
+    $inject= new Injector(new ConfiguredBindings($this->loadProperties('
+      inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem("/path", true)
+    ')));
+    $this->assertEquals(new FileSystem('/path', true), $inject->get(Storage::class));
+  }
+
+  #[@test]
+  public function array_argument() {
+    $inject= new Injector(new ConfiguredBindings($this->loadProperties('
+      inject.unittest.fixture.Storage=inject.unittest.fixture.Database(["mysql://one", "mysql://two"])
+    ')));
+    $this->assertEquals(new Database(['mysql://one', 'mysql://two']), $inject->get(Storage::class));
   }
 
   #[@test]

--- a/src/test/php/inject/unittest/fixture/Database.class.php
+++ b/src/test/php/inject/unittest/fixture/Database.class.php
@@ -1,0 +1,9 @@
+<?php namespace inject\unittest\fixture;
+
+class Database implements Storage {
+  private $dsns;
+
+  public function __construct(array $dsns) {
+    $this->dsns= $dsns;
+  }
+}

--- a/src/test/php/inject/unittest/fixture/FileSystem.class.php
+++ b/src/test/php/inject/unittest/fixture/FileSystem.class.php
@@ -1,9 +1,10 @@
 <?php namespace inject\unittest\fixture;
 
 class FileSystem implements Storage {
-  private $path;
+  private $path, $resolve;
 
-  public function __construct($path= '/') {
+  public function __construct($path= '/', $resolve= false) {
     $this->path= $path;
+    $this->resolve= $resolve;
   }
 }


### PR DESCRIPTION
The following is the equivalent of binding `new SessionServer('sessions.server.lan', ['172.17.'])`:

```ini
web.session.Sessions=com.example.SessionServer("sessions.server.lan", ["172.17."])
                                                                      ^^^^^^^^^^^
                                                                      Arrays supported:)
```

This makes code like this obsolete:

```ini
string[sessions.allowed]=172.17.
string[sessions.balancer]=sessions.server.lan
```

```php
$balancer= $inject->get('string', 'sessions.balancer');
$allowed= explode(',', $inject->get('string', 'sessions.allowed'));
$inject->bind(Sessions::class, new SessionServer($balancer, $allowed));
```
