### PR TITLE
Allow `[@inject("name")]` as short form of `[@inject(name= "name")]`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@ Dependency injection for the XP Framework change log
 
 ## ?.?.? / ????-??-??
 
+* Added PHP 7.3 and PHP 7.4 to test matrix - @thekid
+
 ## 4.2.0 / 2018-05-22
 
 * Implemented feature request #18: Injection names. Names are now calculated

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -145,8 +145,13 @@ class Injector {
         $inject= [];
       }
 
-      $type= isset($inject['type']) ? Type::forName($inject['type']) : ($param->getTypeRestriction() ?: $param->getType());
-      $binding= $this->get($type, isset($inject['name']) ? $inject['name'] : null);
+      if (is_array($inject)) {
+        $type= isset($inject['type']) ? Type::forName($inject['type']) : ($param->getTypeRestriction() ?: $param->getType());
+        $binding= $this->get($type, isset($inject['name']) ? $inject['name'] : null);
+      } else {
+        $type= $param->getTypeRestriction() ?: $param->getType();
+        $binding= $this->get($type, $inject);
+      }
 
       if (null !== $binding) {
         $args[]= $binding;

--- a/src/test/php/inject/unittest/NewInstanceTest.class.php
+++ b/src/test/php/inject/unittest/NewInstanceTest.class.php
@@ -54,12 +54,23 @@ class NewInstanceTest extends TestCase {
   }
 
   #[@test]
-  public function newInstance_performs_named_injection() {
+  public function newInstance_performs_named_injection_using_array_form() {
     $inject= new Injector();
     $inject->bind(TestCase::class, $this, 'test');
     $storage= $this->newStorage([
       'injected' => null,
       '#[@inject(name= "test")] __construct' => function(TestCase $param) { $this->injected= $param; }
+    ]);
+    $this->assertEquals($this, $inject->newInstance($storage)->injected);
+  }
+
+  #[@test]
+  public function newInstance_performs_named_injection_using_string_form() {
+    $inject= new Injector();
+    $inject->bind(TestCase::class, $this, 'test');
+    $storage= $this->newStorage([
+      'injected' => null,
+      '#[@inject("test")] __construct' => function(TestCase $param) { $this->injected= $param; }
     ]);
     $this->assertEquals($this, $inject->newInstance($storage)->injected);
   }


### PR DESCRIPTION
Current functionality:

```php
class Urls {
  public function __construct(<<inject(['name' => 'db-dsn'])>> string $dsn) {
    // ...
  }
}
```

This can now be abbreviated to the following:

```php
class Urls {
  public function __construct(<<inject('db-dsn')>> string $dsn) {
    // ...
  }
}
```
