### PR TITLE
Binding DSL

### DIFF
--- a/src/main/php/inject/Bindings.class.php
+++ b/src/main/php/inject/Bindings.class.php
@@ -9,6 +9,13 @@
 abstract class Bindings {
 
   /**
+   * Creates a new fluent Bindings instance
+   *
+   * @return  self
+   */
+  public static function using() { return new UseBindings(); }
+
+  /**
    * Configures bindings on given injector
    *
    * @param  inject.Injector $injector

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -90,6 +90,20 @@ class Injector {
   }
 
   /**
+   * Add a binding
+   *
+   * @param  string|lang.Type $type
+   * @param  iinject.Binding $binding
+   * @param  string $name
+   * @return self
+   */
+  public function binding($type, Binding $binding, $name= null) {
+    $t= $type instanceof Type ? $type : Type::forName($type);
+    $this->bindings[$t->literal()][$name]= $binding;
+    return $this;
+  }
+
+  /**
    * Get a binding
    *
    * @param  string|lang.Type $type

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -29,7 +29,7 @@ class Injector {
   public function __construct(... $initial) {
     $this->bind(typeof($this), $this);
     foreach ($initial as $bindings) {
-      $this->add($bindings);
+      $bindings->configure($this);
     }
   }
 
@@ -59,13 +59,27 @@ class Injector {
    * @param  inject.Bindings $bindings
    * @return self
    */
-  public function add(Bindings $bindings) {
+  public function with(Bindings $bindings) {
     $bindings->configure($this);
     return $this;
   }
 
   /**
-   * Add a binding
+   * Add a given binding for a given type
+   *
+   * @param  string|lang.Type $type
+   * @param  iinject.Binding $binding
+   * @param  string $name
+   * @return self
+   */
+  public function add($type, Binding $binding, $name= null) {
+    $t= $type instanceof Type ? $type : Type::forName($type);
+    $this->bindings[$t->literal()][$name]= $binding;
+    return $this;
+  }
+
+  /**
+   * Bind to a given type
    *
    * @param  string|lang.Type $type
    * @param  var $impl
@@ -86,20 +100,6 @@ class Injector {
     } else {
       $this->bindings[$t->literal()][$name]= self::asBinding($t, $impl);
     }
-    return $this;
-  }
-
-  /**
-   * Add a binding
-   *
-   * @param  string|lang.Type $type
-   * @param  iinject.Binding $binding
-   * @param  string $name
-   * @return self
-   */
-  public function binding($type, Binding $binding, $name= null) {
-    $t= $type instanceof Type ? $type : Type::forName($type);
-    $this->bindings[$t->literal()][$name]= $binding;
     return $this;
   }
 

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -59,22 +59,8 @@ class Injector {
    * @param  inject.Bindings $bindings
    * @return self
    */
-  public function with(Bindings $bindings) {
+  public function add(Bindings $bindings) {
     $bindings->configure($this);
-    return $this;
-  }
-
-  /**
-   * Add a given binding for a given type
-   *
-   * @param  string|lang.Type $type
-   * @param  iinject.Binding $binding
-   * @param  string $name
-   * @return self
-   */
-  public function add($type, Binding $binding, $name= null) {
-    $t= $type instanceof Type ? $type : Type::forName($type);
-    $this->bindings[$t->literal()][$name]= $binding;
     return $this;
   }
 
@@ -96,9 +82,9 @@ class Injector {
       if (null === $name) {
         throw new IllegalArgumentException('Cannot bind primitive type '.$t.' without a name');
       }
-      $this->bindings[$t->literal()][$name]= new InstanceBinding($impl, $t);
+      $this->bindings[$t->literal()][$name]= $impl instanceof Binding ? $impl : new InstanceBinding($impl, $t);
     } else {
-      $this->bindings[$t->literal()][$name]= self::asBinding($t, $impl);
+      $this->bindings[$t->literal()][$name]= $impl instanceof Binding ? $impl : self::asBinding($t, $impl);
     }
     return $this;
   }

--- a/src/main/php/inject/SingletonBinding.class.php
+++ b/src/main/php/inject/SingletonBinding.class.php
@@ -3,22 +3,20 @@
 use lang\IllegalArgumentException;
 use lang\XPClass;
 
-class ClassBinding implements Binding {
-  protected $class;
+class SingletonBinding implements Binding {
+  private $class;
+  private $instance= null;
 
   /**
-   * Creates a new instance binding
+   * Creates a new singleton binding
    *
    * @param  string|lang.XPClass $class
-   * @param  lang.XPClass $type
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($class, $type= null) {
+  public function __construct($class) {
     $c= $class instanceof XPClass ? $class : XPClass::forName($class);
-    if ($type && !$type->isAssignableFrom($c)) {
-      throw new IllegalArgumentException($c.' is not an instance of '.$type);
-    } else if ($c->isInterface() || $c->getModifiers() & MODIFIER_ABSTRACT) {
-      throw new IllegalArgumentException('Cannot bind to non-concrete type '.$type);
+    if ($c->isInterface() || $c->getModifiers() & MODIFIER_ABSTRACT) {
+      throw new IllegalArgumentException('Cannot bind to non-concrete type '.$c);
     }
 
     $this->class= $c;
@@ -31,7 +29,7 @@ class ClassBinding implements Binding {
    * @param  inject.Provider<?>
    */
   public function provider($injector) {
-    return new TypeProvider($this->class, $injector);
+    return new ResolvingProvider($this, $injector);
   }
 
   /**
@@ -41,6 +39,6 @@ class ClassBinding implements Binding {
    * @param  var
    */
   public function resolve($injector) {
-    return $injector->newInstance($this->class);
+    return $this->instance ?: $this->instance= $injector->newInstance($this->class);
   }
 }

--- a/src/main/php/inject/UseBindings.class.php
+++ b/src/main/php/inject/UseBindings.class.php
@@ -66,7 +66,7 @@ class UseBindings extends Bindings {
    */
   public function configure($injector) {
     foreach ($this->bindings as $b) {
-      $injector->binding(...$b);
+      $injector->add(...$b);
     }
   }
 }

--- a/src/main/php/inject/UseBindings.class.php
+++ b/src/main/php/inject/UseBindings.class.php
@@ -21,7 +21,7 @@ class UseBindings extends Bindings {
    */
   public function typed($type, $impl= null) {
     $this->configure[]= function($injector) use($type, $impl) {
-      $injector->add($type, new ClassBinding($impl ?: $type));
+      $injector->bind($type, new ClassBinding($impl ?: $type));
     };
     return $this;
   }
@@ -36,7 +36,7 @@ class UseBindings extends Bindings {
    */
   public function singleton($type, $impl= null) {
     $this->configure[]= function($injector) use($type, $impl) {
-      $injector->add($type, new SingletonBinding($impl ?: $type));
+      $injector->bind($type, new SingletonBinding($impl ?: $type));
     };
     return $this;
   }
@@ -50,7 +50,7 @@ class UseBindings extends Bindings {
    */
   public function named($name, $instance) {
     $this->configure[]= function($injector) use($instance, $name) {
-      $injector->add(typeof($instance), new InstanceBinding($instance), $name);
+      $injector->bind(typeof($instance), new InstanceBinding($instance), $name);
     };
     return $this;
   }
@@ -63,7 +63,7 @@ class UseBindings extends Bindings {
    */
   public function instance($instance) {
     $this->configure[]= function($injector) use($instance) {
-      $injector->add(typeof($instance), new InstanceBinding($instance));
+      $injector->bind(typeof($instance), new InstanceBinding($instance));
     };
     return $this;
   }

--- a/src/main/php/inject/UseBindings.class.php
+++ b/src/main/php/inject/UseBindings.class.php
@@ -1,0 +1,72 @@
+<?php namespace inject;
+
+/**
+ * Fluent interface
+ *
+ * @see   inject.Bindings::using()
+ * @test  xp://inject.unittest.UseBindingsTest
+ */
+class UseBindings extends Bindings {
+  private $bindings= [];
+
+  /**
+   * Binds a given type to a given implementing type, creating a new
+   * instance every time `$inject->get()` is invoked.
+   *
+   * @param  string|lang.Type $type
+   * @param  ?(string|lang.Type) $impl Defaults to type itself
+   * @return self
+   */
+  public function typed($type, $impl= null) {
+    $this->bindings[]= [$type, new ClassBinding($impl ?: $type)];
+    return $this;
+  }
+
+  /**
+   * Binds a given type to a given implementing type, ensuring only a
+   * single instance of it will exist.
+   *
+   * @param  string|lang.Type $type
+   * @param  ?(string|lang.Type) $impl Defaults to type itself
+   * @return self
+   */
+  public function singleton($type, $impl= null) {
+    $this->bindings[]= [$type, new SingletonBinding($impl ?: $type)];
+    return $this;
+  }
+
+  /**
+   * Binds a give instance to its type and a given name
+   *
+   * @param  string $name
+   * @param  var $instance
+   * @return self
+   */
+  public function named($name, $instance) {
+    $this->bindings[]= [typeof($instance), new InstanceBinding($instance), $name];
+    return $this;
+  }
+
+  /**
+   * Binds a give instance to its type
+   *
+   * @param  var $instance
+   * @return self
+   */
+  public function instance($instance) {
+    $this->bindings[]= [typeof($instance), new InstanceBinding($instance)];
+    return $this;
+  }
+
+
+  /**
+   * Configures bindings on given injector
+   *
+   * @param  inject.Injector $injector
+   */
+  public function configure($injector) {
+    foreach ($this->bindings as $b) {
+      $injector->binding(...$b);
+    }
+  }
+}

--- a/src/main/php/inject/UseBindings.class.php
+++ b/src/main/php/inject/UseBindings.class.php
@@ -76,7 +76,7 @@ class UseBindings extends Bindings {
    */
   public function properties(PropertyAccess $properties) {
     $this->configure[]= function($injector) use($properties) {
-      $injector->with(new ConfiguredBindings($properties));
+      $injector->add(new ConfiguredBindings($properties));
     };
     return $this;
   }

--- a/src/test/php/inject/unittest/BindingsTest.class.php
+++ b/src/test/php/inject/unittest/BindingsTest.class.php
@@ -4,8 +4,8 @@ use inject\Bindings;
 use inject\Injector;
 use inject\unittest\fixture\FileSystem;
 use inject\unittest\fixture\Storage;
-use util\Currency;
 use unittest\TestCase;
+use util\Currency;
 
 class BindingsTest extends TestCase {
   protected $bindings;
@@ -40,13 +40,13 @@ class BindingsTest extends TestCase {
   #[@test]
   public function add_returns_injector() {
     $inject= new Injector();
-    $this->assertEquals($inject, $inject->add($this->bindings));
+    $this->assertEquals($inject, $inject->with($this->bindings));
   }
 
   #[@test]
   public function add() {
     $inject= new Injector();
-    $inject->add($this->bindings);
+    $inject->with($this->bindings);
     $this->assertInstanceOf(FileSystem::class, $inject->get(Storage::class));
   }
 }

--- a/src/test/php/inject/unittest/BindingsTest.class.php
+++ b/src/test/php/inject/unittest/BindingsTest.class.php
@@ -40,13 +40,13 @@ class BindingsTest extends TestCase {
   #[@test]
   public function add_returns_injector() {
     $inject= new Injector();
-    $this->assertEquals($inject, $inject->with($this->bindings));
+    $this->assertEquals($inject, $inject->add($this->bindings));
   }
 
   #[@test]
   public function add() {
     $inject= new Injector();
-    $inject->with($this->bindings);
+    $inject->add($this->bindings);
     $this->assertInstanceOf(FileSystem::class, $inject->get(Storage::class));
   }
 }

--- a/src/test/php/inject/unittest/UseBindingsTest.class.php
+++ b/src/test/php/inject/unittest/UseBindingsTest.class.php
@@ -1,0 +1,58 @@
+<?php namespace inject\unittest;
+
+use inject\Bindings;
+use inject\Injector;
+use inject\UseBindings;
+use inject\unittest\fixture\FileSystem;
+use inject\unittest\fixture\Storage;
+use unittest\TestCase;
+
+class UseBindingsTest extends TestCase {
+
+  #[@test]
+  public function using_creates_fluent_interface() {
+    $this->assertInstanceOf(UseBindings::class, Bindings::using());
+  }
+
+  #[@test]
+  public function typed() {
+    $inject= new Injector(Bindings::using()->typed(Storage::class, FileSystem::class));
+    $this->assertInstanceOf(FileSystem::class, $inject->get(Storage::class));
+  }
+
+  #[@test]
+  public function typed_produces_different_instances() {
+    $inject= new Injector(Bindings::using()->typed(Storage::class, FileSystem::class));
+    $a= $inject->get(Storage::class);
+    $b= $inject->get(Storage::class);
+    $this->assertFalse($a === $b, 'same instance');
+  }
+
+  #[@test]
+  public function singleton() {
+    $inject= new Injector(Bindings::using()->singleton(Storage::class, FileSystem::class));
+    $this->assertInstanceOf(FileSystem::class, $inject->get(Storage::class));
+  }
+
+  #[@test]
+  public function singleton_produces_same_instance() {
+    $inject= new Injector(Bindings::using()->singleton(Storage::class, FileSystem::class));
+    $a= $inject->get(Storage::class);
+    $b= $inject->get(Storage::class);
+    $this->assertTrue($a === $b, 'same instance');
+  }
+
+  #[@test]
+  public function named() {
+    $cwd= new FileSystem('.');
+    $inject= new Injector(Bindings::using()->named('cwd', $cwd));
+    $this->assertEquals($cwd, $inject->get(FileSystem::class, 'cwd'));
+  }
+
+  #[@test]
+  public function instance() {
+    $cwd= new FileSystem('.');
+    $inject= new Injector(Bindings::using()->instance($cwd));
+    $this->assertEquals($cwd, $inject->get(FileSystem::class));
+  }
+}

--- a/src/test/php/inject/unittest/UseBindingsTest.class.php
+++ b/src/test/php/inject/unittest/UseBindingsTest.class.php
@@ -5,7 +5,9 @@ use inject\Injector;
 use inject\UseBindings;
 use inject\unittest\fixture\FileSystem;
 use inject\unittest\fixture\Storage;
+use io\streams\MemoryInputStream;
 use unittest\TestCase;
+use util\Properties;
 
 class UseBindingsTest extends TestCase {
 
@@ -54,5 +56,13 @@ class UseBindingsTest extends TestCase {
     $cwd= new FileSystem('.');
     $inject= new Injector(Bindings::using()->instance($cwd));
     $this->assertEquals($cwd, $inject->get(FileSystem::class));
+  }
+
+  #[@test]
+  public function properties() {
+    $p= new Properties(null);
+    $p->load(new MemoryInputStream('inject.unittest.fixture.Storage=inject.unittest.fixture.FileSystem'));
+    $inject= new Injector(Bindings::using()->properties($p));
+    $this->assertEquals(new FileSystem('/'), $inject->get(Storage::class));
   }
 }


### PR DESCRIPTION
The following usage patterns exist:

```php
$inject= new Injector(new ConfiguredBindings(new Properties('app.ini')));

// Bind interface to implementation, the "default" usage
$inject->bind(Repository::class, InDatabase::class);

// Named
$inject->bind(Path::class, new Path($webroot, 'src/main/handlebars'), 'templates');

// Instances
$inject->bind(DBConnection::class, $conn);

// Singleton
$inject->bind(TemplateEngine::class, $inject->get(TemplateEngine::class));
```

Here's the DSL form of the above:

```php
$injector= new Injector(Bindings::using()
  ->properties(new Properties('app.ini'))
  ->typed(Repository::class, InDatabase::class)
  ->named('templates', new Path($webroot, 'src/main/handlebars'))
  ->instance(DriverManager::getConnection($dsn))
  ->singleton(TemplateEngine::class)
);
```

See #22