### PR TITLE
Wrap instance creation errors in instanceOf()

### DIFF
--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -157,6 +157,7 @@ class Injector {
    * @param  lang.XPClass $class
    * @param  [:var] $named
    * @return inject.Binding
+   * @throws inject.ProvisionException
    */
   private function instanceOf($class, $named= []) {
     if (!$class->hasConstructor()) return new InstanceBinding($class->newInstance());
@@ -182,6 +183,7 @@ class Injector {
    * @param  string|lang.Type $type
    * @param  ?string $name
    * @return inject.Binding
+   * @throws inject.ProvisionException
    */
   public function binding($type, $name= null) {
     $t= $type instanceof Type ? $type : Type::forName($type);

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -165,12 +165,14 @@ class Injector {
     $arguments= $this->argumentsOf($constructor, $named);
     if (!$this->provided($arguments)) return $arguments;
 
+    // Wrap any exception caught during instance creation. These errors
+    // should not be simply returned as we risk them being overlooked!
     try {
       return new InstanceBinding($constructor->newInstance($arguments->resolve($this)));
     } catch (TargetInvocationException $e) {
-      return new ProvisionException('Error creating an instance of '.$class->getName(), $e->getCause());
+      throw new ProvisionException('Error creating an instance of '.$class->getName(), $e->getCause());
     } catch (Throwable $e) {
-      return new ProvisionException('Error creating an instance of '.$class->getName(), $e);
+      throw new ProvisionException('Error creating an instance of '.$class->getName(), $e);
     }
   }
 

--- a/src/test/php/inject/unittest/NewInstanceTest.class.php
+++ b/src/test/php/inject/unittest/NewInstanceTest.class.php
@@ -36,7 +36,7 @@ class NewInstanceTest {
     try {
       return $inject->newInstance($type);
     } catch (ProvisionException $e) {
-      throw $e->getCause();
+      throw $e->getCause() ?? $e;
     }
   }
 


### PR DESCRIPTION
This way, code from the outside will only have to catch `inject.ProvisionException` instances. If necessary, their cause can be accessed for details.