### PR TITLE
Simplify string bindings

### DIFF
--- a/src/main/php/inject/ConfiguredBindings.class.php
+++ b/src/main/php/inject/ConfiguredBindings.class.php
@@ -92,17 +92,19 @@ class ConfiguredBindings extends Bindings {
    * @param  lang.ClassLoader $cl
    * @param  string[] $namespaces
    * @param  string $name
-   * @return lang.XPClass
+   * @return ?lang.XPClass
+   * @throws lang.ClassNotFoundException
    */
   private function resolveType($cl, $namespaces, $name) {
     if (strstr($name, '.')) {
       return $cl->loadClass($name);
-    } else {
+    } else if (0 === strspn($name[0], 'abcdefghijklmnopqrstuvwxyz')) {
       foreach ($namespaces as $namespace) {
         if ($cl->providesClass($qualified= $namespace.'.'.$name)) return $cl->loadClass($qualified);
       }
       throw new ClassNotFoundException('['.implode(', ', $namespaces).'].'.$name);
     }
+    return null;
   }
 
   /**
@@ -142,12 +144,15 @@ class ConfiguredBindings extends Bindings {
           continue;
         }
 
+        // Strings: `named=value`
+        // Primitives: `string[named]=value`
+        // Implementations: `package.Storage=package.FileSystem`
+        // Named implementations: `package.Storage[files]=package.FileSystem`
         if (isset(self::$PRIMITIVES[$type])) {
           foreach ($implementation as $name => $value) {
             $injector->bind($type, $this->valueIn($value), $name);
           }
-        } else {
-          $resolved= $this->resolveType($cl, $namespaces, $type);
+        } else if ($resolved= $this->resolveType($cl, $namespaces, $type)) {
           if (is_array($implementation)) {
             foreach ($implementation as $name => $impl) {
               $injector->bind($resolved, $this->bindingTo($cl, $namespaces, $impl), $name);
@@ -155,6 +160,8 @@ class ConfiguredBindings extends Bindings {
           } else {
             $injector->bind($resolved, $this->bindingTo($cl, $namespaces, $implementation));
           }
+        } else {
+          $injector->bind('string', $implementation, $type);
         }
       }
     }

--- a/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
+++ b/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
@@ -72,7 +72,17 @@ class ConfiguredBindingsTest {
   #[Test, Expect(ClassNotFoundException::class)]
   public function bind_implementation_when_plain_key_starts_with_uppercase() {
     $inject= new Injector(new ConfiguredBindings($this->loadProperties('Test=Test')));
-    $inject->get('string', 'test');
+    $inject->get('Test');
+  }
+
+  #[Test, Expect(ClassNotFoundException::class)]
+  public function bind_implementation_when_plain_key_starts_with_uppercase_with_use() {
+    $inject= new Injector(new ConfiguredBindings($this->loadProperties('
+      use[]=inject.unittest.fixture
+
+      Test=Test
+    ')));
+    $inject->get('Test');
   }
 
   #[Test]

--- a/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
+++ b/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
@@ -76,6 +76,12 @@ class ConfiguredBindingsTest {
   }
 
   #[Test, Expect(ClassNotFoundException::class)]
+  public function plain_value_in_type_binding_yields_error() {
+    $inject= new Injector(new ConfiguredBindings($this->loadProperties('inject.unittest.fixture.Storage=test')));
+    $inject->get(Storage::class);
+  }
+
+  #[Test, Expect(ClassNotFoundException::class)]
   public function bind_implementation_when_plain_key_starts_with_uppercase_with_use() {
     $inject= new Injector(new ConfiguredBindings($this->loadProperties('
       use[]=inject.unittest.fixture

--- a/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
+++ b/src/test/php/inject/unittest/ConfiguredBindingsTest.class.php
@@ -64,6 +64,18 @@ class ConfiguredBindingsTest {
   }
 
   #[Test]
+  public function bind_string_when_plain_key_starts_with_lowercase() {
+    $inject= new Injector(new ConfiguredBindings($this->loadProperties('test=Test')));
+    Assert::equals('Test', $inject->get('string', 'test'));
+  }
+
+  #[Test, Expect(ClassNotFoundException::class)]
+  public function bind_implementation_when_plain_key_starts_with_uppercase() {
+    $inject= new Injector(new ConfiguredBindings($this->loadProperties('Test=Test')));
+    $inject->get('string', 'test');
+  }
+
+  #[Test]
   public function bind_named_class() {
     $inject= new Injector(new ConfiguredBindings($this->loadProperties('
       inject.unittest.fixture.Storage[files]=inject.unittest.fixture.FileSystem


### PR DESCRIPTION
This pull request simplifies string bindings in `inject.ConfiguredBindings`. String bindings are the most common case.

## Before
Formerly, string values were bound as named types, which was directly reflected in the INI file syntax:

```ini
; Implementations
scriptlet.Session=com.example.session.FileSystem

; Named strings
string[api]=https://${secret.access-token}@api.example.com/api/v1
```

## After
While the above continues to work, bindings where the key starts with a lowercase letter are considered named string bindings, and the above (while continuing to work) can be simplified to the following:

```ini
; Implementations
scriptlet.Session=com.example.session.FileSystem

; Named strings
api=https://${secret.access-token}@api.example.com/api/v1
```

👉 *Note: To disambiguate between type names in the global namespace and named strings, keys starting with a lowercase letter are regarded a name, otherwise being handled as a type: `test=Works` is a named string, while `Test=Works` is a typed binding.*

## See also

* https://github.com/xp-forge/inject/issues/20#issuecomment-423840046