### PR TITLE
Migrate to new reflection API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0 | ^9.0 | ^8.0 | ^7.0",
+    "xp-framework/reflection": "^2.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -1,6 +1,5 @@
 <?php namespace inject;
 
-use lang\reflection\CannotInstantiate;
 use lang\{IllegalArgumentException, Nullable, Primitive, Throwable, Type, TypeUnion, XPClass, Reflection};
 
 /**

--- a/src/test/php/inject/unittest/AnnotatedConstructorTest.class.php
+++ b/src/test/php/inject/unittest/AnnotatedConstructorTest.class.php
@@ -12,7 +12,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function with_inject_annotation_and_type() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[\inject\Inject(type: "inject.unittest.AnnotationsTest")] __construct' => function($param) {
+      '#[Inject(type: "inject.unittest.AnnotationsTest")] __construct' => function($param) {
         $this->injected= $param;
       }
     ]));
@@ -23,7 +23,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function with_inject_annotation_and_restriction() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[\inject\Inject] __construct' => function(AnnotationsTest $param) { $this->injected= $param; }
+      '#[Inject] __construct' => function(AnnotationsTest $param) { $this->injected= $param; }
     ]));
     Assert::equals($this, $this->inject->get(Value::class)->injected);
   }
@@ -32,7 +32,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function optional_bound_parameter() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[\inject\Inject] __construct' => function(AnnotationsTest $test= null) { $this->injected= $test; }
+      '#[Inject] __construct' => function(AnnotationsTest $test= null) { $this->injected= $test; }
     ]));
     Assert::equals($this, $this->inject->get(Value::class)->injected);
   }
@@ -41,7 +41,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function optional_unbound_parameter() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[\inject\Inject] __construct' => function(AnnotationsTest $test, $verify= true) { $this->injected= [$test, $verify]; }
+      '#[Inject] __construct' => function(AnnotationsTest $test, $verify= true) { $this->injected= [$test, $verify]; }
     ]));
     Assert::equals([$this, true], $this->inject->get(Value::class)->injected);
   }
@@ -51,7 +51,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
     $this->inject->bind('string', 'Test', 'name');
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[\inject\Inject] __construct' => function(string $name= '') { $this->injected= $name; }
+      '#[Inject] __construct' => function(string $name= '') { $this->injected= $name; }
     ]));
     Assert::equals('Test', $this->inject->get(Value::class)->injected);
   }
@@ -60,7 +60,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function with_inject_annotation_and_multiple_parameters() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[\inject\Inject] __construct' => function(AnnotationsTest $test, Storage $storage) {
+      '#[Inject] __construct' => function(AnnotationsTest $test, Storage $storage) {
         $this->injected= [$test, $storage];
       }
     ]));
@@ -73,9 +73,9 @@ class AnnotatedConstructorTest extends AnnotationsTest {
       public $injected;
 
       public function __construct(
-        #[\inject\Inject]
-        \inject\unittest\AnnotationsTest $test,
-        #[\inject\Inject(name: "EUR")]
+        #[Inject]
+        unittest\AnnotationsTest $test,
+        #[Inject(name: "EUR")]
         \util\Currency $cur
       ) {
         $this->injected= [$test, $cur];
@@ -89,11 +89,11 @@ class AnnotatedConstructorTest extends AnnotationsTest {
     $this->inject->bind(Value::class, $this->newInstance('{
       public $injected;
 
-      #[\inject\Inject]
+      #[Inject]
       public function __construct(
-        \inject\unittest\AnnotationsTest $test,
-        \inject\unittest\fixture\Storage $storage,
-        #[\inject\Inject(name: "name", type: "string")]
+        unittest\AnnotationsTest $test,
+        unittest\fixture\Storage $storage,
+        #[Inject(name: "name", type: "string")]
         $name
       ) {
         $this->injected= [$test, $storage, $name];
@@ -105,7 +105,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   #[Test, Expect(class: ProvisionException::class, message: '/No bound value for type lang.Runnable/')]
   public function injecting_unbound_into_constructor_via_method_annotation() {
     $this->inject->bind(Value::class, $this->newInstance([
-      '#[\inject\Inject] __construct' => function(Runnable $param) { /* Empty */ }
+      '#[Inject] __construct' => function(Runnable $param) { /* Empty */ }
     ]));
     $this->inject->get(Value::class);
   }
@@ -113,9 +113,9 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   #[Test, Expect(class: ProvisionException::class, message: '/No bound value for type lang.Runnable/')]
   public function injecting_unbound_into_constructor_via_parameter_annotation() {
     $this->inject->bind(Value::class, $this->newInstance('{
-      #[\inject\Inject]
+      #[Inject]
       public function __construct(
-        #[\inject\Inject]
+        #[Inject]
         \lang\Runnable $param
       ) { }
     }'));
@@ -154,7 +154,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function name_defaults_to_parameter() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[\inject\Inject] __construct' => function(AnnotationsTest $test, Storage $storage, string $name) {
+      '#[Inject] __construct' => function(AnnotationsTest $test, Storage $storage, string $name) {
         $this->injected= [$test, $storage, $name];
       }
     ]));

--- a/src/test/php/inject/unittest/AnnotatedConstructorTest.class.php
+++ b/src/test/php/inject/unittest/AnnotatedConstructorTest.class.php
@@ -74,7 +74,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
 
       public function __construct(
         #[Inject]
-        unittest\AnnotationsTest $test,
+        \inject\unittest\AnnotationsTest $test,
         #[Inject(name: "EUR")]
         \util\Currency $cur
       ) {
@@ -91,8 +91,8 @@ class AnnotatedConstructorTest extends AnnotationsTest {
 
       #[Inject]
       public function __construct(
-        unittest\AnnotationsTest $test,
-        unittest\fixture\Storage $storage,
+        \inject\unittest\AnnotationsTest $test,
+        \inject\unittest\fixture\Storage $storage,
         #[Inject(name: "name", type: "string")]
         $name
       ) {

--- a/src/test/php/inject/unittest/AnnotatedConstructorTest.class.php
+++ b/src/test/php/inject/unittest/AnnotatedConstructorTest.class.php
@@ -12,7 +12,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function with_inject_annotation_and_type() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[Inject(["type" => "inject.unittest.AnnotationsTest"])] __construct' => function($param) {
+      '#[\inject\Inject(type: "inject.unittest.AnnotationsTest")] __construct' => function($param) {
         $this->injected= $param;
       }
     ]));
@@ -23,7 +23,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function with_inject_annotation_and_restriction() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[Inject] __construct' => function(AnnotationsTest $param) { $this->injected= $param; }
+      '#[\inject\Inject] __construct' => function(AnnotationsTest $param) { $this->injected= $param; }
     ]));
     Assert::equals($this, $this->inject->get(Value::class)->injected);
   }
@@ -32,7 +32,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function optional_bound_parameter() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[Inject] __construct' => function(AnnotationsTest $test= null) { $this->injected= $test; }
+      '#[\inject\Inject] __construct' => function(AnnotationsTest $test= null) { $this->injected= $test; }
     ]));
     Assert::equals($this, $this->inject->get(Value::class)->injected);
   }
@@ -41,7 +41,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function optional_unbound_parameter() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[Inject] __construct' => function(AnnotationsTest $test, $verify= true) { $this->injected= [$test, $verify]; }
+      '#[\inject\Inject] __construct' => function(AnnotationsTest $test, $verify= true) { $this->injected= [$test, $verify]; }
     ]));
     Assert::equals([$this, true], $this->inject->get(Value::class)->injected);
   }
@@ -51,7 +51,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
     $this->inject->bind('string', 'Test', 'name');
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[Inject] __construct' => function(string $name= '') { $this->injected= $name; }
+      '#[\inject\Inject] __construct' => function(string $name= '') { $this->injected= $name; }
     ]));
     Assert::equals('Test', $this->inject->get(Value::class)->injected);
   }
@@ -60,7 +60,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function with_inject_annotation_and_multiple_parameters() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[Inject] __construct' => function(AnnotationsTest $test, Storage $storage) {
+      '#[\inject\Inject] __construct' => function(AnnotationsTest $test, Storage $storage) {
         $this->injected= [$test, $storage];
       }
     ]));
@@ -73,9 +73,9 @@ class AnnotatedConstructorTest extends AnnotationsTest {
       public $injected;
 
       public function __construct(
-        #[Inject]
+        #[\inject\Inject]
         \inject\unittest\AnnotationsTest $test,
-        #[Inject(name: "EUR")]
+        #[\inject\Inject(name: "EUR")]
         \util\Currency $cur
       ) {
         $this->injected= [$test, $cur];
@@ -89,11 +89,11 @@ class AnnotatedConstructorTest extends AnnotationsTest {
     $this->inject->bind(Value::class, $this->newInstance('{
       public $injected;
 
-      #[Inject]
+      #[\inject\Inject]
       public function __construct(
         \inject\unittest\AnnotationsTest $test,
         \inject\unittest\fixture\Storage $storage,
-        #[Inject(name: "name", type: "string")]
+        #[\inject\Inject(name: "name", type: "string")]
         $name
       ) {
         $this->injected= [$test, $storage, $name];
@@ -105,7 +105,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   #[Test, Expect(class: ProvisionException::class, message: '/No bound value for type lang.Runnable/')]
   public function injecting_unbound_into_constructor_via_method_annotation() {
     $this->inject->bind(Value::class, $this->newInstance([
-      '#[Inject] __construct' => function(Runnable $param) { /* Empty */ }
+      '#[\inject\Inject] __construct' => function(Runnable $param) { /* Empty */ }
     ]));
     $this->inject->get(Value::class);
   }
@@ -113,9 +113,9 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   #[Test, Expect(class: ProvisionException::class, message: '/No bound value for type lang.Runnable/')]
   public function injecting_unbound_into_constructor_via_parameter_annotation() {
     $this->inject->bind(Value::class, $this->newInstance('{
-      #[Inject]
+      #[\inject\Inject]
       public function __construct(
-        #[Inject]
+        #[\inject\Inject]
         \lang\Runnable $param
       ) { }
     }'));
@@ -154,7 +154,7 @@ class AnnotatedConstructorTest extends AnnotationsTest {
   public function name_defaults_to_parameter() {
     $this->inject->bind(Value::class, $this->newInstance([
       'injected' => null,
-      '#[Inject] __construct' => function(AnnotationsTest $test, Storage $storage, string $name) {
+      '#[\inject\Inject] __construct' => function(AnnotationsTest $test, Storage $storage, string $name) {
         $this->injected= [$test, $storage, $name];
       }
     ]));

--- a/src/test/php/inject/unittest/AnnotationsTest.class.php
+++ b/src/test/php/inject/unittest/AnnotationsTest.class.php
@@ -8,7 +8,6 @@ use util\Currency;
 
 abstract class AnnotationsTest {
   protected $inject;
-  protected $id= 0;
 
   #[Before]
   public function inject() {
@@ -27,7 +26,7 @@ abstract class AnnotationsTest {
    */
   protected function newInstance($definition) {
     return ClassLoader::defineClass(
-      'inject.unittest.fixture.AnnotationsTest_'.($this->id++),
+      'inject.AnnotationsTest_'.uniqid(),
       Value::class,
       [],
       $definition

--- a/src/test/php/inject/unittest/NewInstanceTest.class.php
+++ b/src/test/php/inject/unittest/NewInstanceTest.class.php
@@ -14,11 +14,11 @@ class NewInstanceTest {
    * Creates a unique and new fixture subclass with the given definition
    *
    * @param  [:var] $definition
-   * @return inject.unittest.fixture.Storage
+   * @return inject.unittest.fixture.Fixture
    */
   protected function newFixture($definition) {
     return ClassLoader::defineClass(
-      'inject.unittest.fixture.T'.uniqid(),
+      'inject.NewInstanceTest_'.uniqid(),
       'inject.unittest.fixture.Fixture',
       [],
       $definition
@@ -50,7 +50,7 @@ class NewInstanceTest {
   public function newInstance_performs_injection() {
     $inject= (new Injector())->bind(Storage::class, $this->storage);
     $fixture= $this->newFixture([
-      '#[\inject\Inject] __construct' => function(Storage $param) { $this->injected= $param; }
+      '#[Inject] __construct' => function(Storage $param) { $this->injected= $param; }
     ]);
 
     Assert::equals($this->storage, $inject->newInstance($fixture)->injected);
@@ -60,7 +60,7 @@ class NewInstanceTest {
   public function newInstance_performs_named_injection_using_array_form() {
     $inject= (new Injector())->bind(Storage::class, $this->storage, 'test');
     $fixture= $this->newFixture([
-      '#[\inject\Inject(name: "test")] __construct' => function(Storage $param) { $this->injected= $param; }
+      '#[Inject(name: "test")] __construct' => function(Storage $param) { $this->injected= $param; }
     ]);
 
     Assert::equals($this->storage, $inject->newInstance($fixture)->injected);
@@ -70,7 +70,7 @@ class NewInstanceTest {
   public function newInstance_performs_named_injection_using_string_form() {
     $inject= (new Injector())->bind(Storage::class, $this->storage, 'test');
     $fixture= $this->newFixture([
-      '#[\inject\Inject("test")] __construct' => function(Storage $param) { $this->injected= $param; }
+      '#[Inject("test")] __construct' => function(Storage $param) { $this->injected= $param; }
     ]);
 
     Assert::equals($this->storage, $inject->newInstance($fixture)->injected);
@@ -112,7 +112,7 @@ class NewInstanceTest {
     $inject= new Injector();
     $inject->bind(Storage::class, $this->storage);
     $fixture= $this->newFixture([
-      '#[\inject\Inject] __construct' => function(Storage $param, $verify= true) { $this->injected= [$param, $verify]; }
+      '#[Inject] __construct' => function(Storage $param, $verify= true) { $this->injected= [$param, $verify]; }
     ]);
 
     Assert::equals([$this->storage, true], $inject->newInstance($fixture)->injected);
@@ -121,7 +121,7 @@ class NewInstanceTest {
   #[Test, Expect(class: CannotInstantiate::class, message: '/Cannot instantiate .+/')]
   public function newInstance_catches_cannot_instantiate_when_creating_class_instances() {
     $this->newInstance(new Injector(), $this->newFixture('{
-      #[\inject\Inject]
+      #[Inject]
       private function __construct() { }
     }'));
   }
@@ -129,7 +129,7 @@ class NewInstanceTest {
   #[Test, Expect(class: ProvisionException::class, message: '/No bound value for type string named "endpoint"/')]
   public function newInstance_throws_when_value_for_required_parameter_not_found() {
     $this->newInstance(new Injector(), $this->newFixture('{
-      #[\inject\Inject(type: "string", name: "endpoint")]
+      #[Inject(type: "string", name: "endpoint")]
       public function __construct($uri) { }
     }'));
   }


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/338

## Performance

Before:

```bash
$ xp test src/test/php/
# ...
Test cases:  177 succeeded
Memory used: 3676.30 kB (3730.42 kB peak)
Time taken:  0.031 seconds (0.096 seconds overall)
```
After:

```bash
$ xp test src/test/php/
# ...
Test cases:  177 succeeded
Memory used: 3621.24 kB (3675.37 kB peak)
Time taken:  0.034 seconds (0.107 seconds overall)
```