### PR TITLE
Make it possible to pass instances to `singleton()`

### DIFF
--- a/src/main/php/inject/UseBindings.class.php
+++ b/src/main/php/inject/UseBindings.class.php
@@ -1,5 +1,6 @@
 <?php namespace inject;
 
+use lang\Type;
 use util\PropertyAccess;
 
 /**
@@ -36,7 +37,13 @@ class UseBindings extends Bindings {
    */
   public function singleton($type, $impl= null) {
     $this->configure[]= function($injector) use($type, $impl) {
-      $injector->bind($type, new SingletonBinding($impl ?: $type));
+      if (null === $impl) {
+        $injector->bind($type, new SingletonBinding($type));
+      } else if (is_string($impl) || $impl instanceof Type) {
+        $injector->bind($type, new SingletonBinding($impl));
+      } else {
+        $injector->bind($type, new InstanceBinding($impl));
+      }
     };
     return $this;
   }
@@ -56,7 +63,7 @@ class UseBindings extends Bindings {
   }
 
   /**
-   * Binds a give instance to its type
+   * Binds a given instance to its type.
    *
    * @param  var $instance
    * @return self

--- a/src/test/php/inject/unittest/UseBindingsTest.class.php
+++ b/src/test/php/inject/unittest/UseBindingsTest.class.php
@@ -34,6 +34,13 @@ class UseBindingsTest {
   }
 
   #[Test]
+  public function singleton_uses_same_instance() {
+    $fs= new FileSystem('/');
+    $inject= new Injector(Bindings::using()->singleton(Storage::class, $fs));
+    Assert::true($fs === $inject->get(Storage::class), 'same instance');
+  }
+
+  #[Test]
   public function singleton_produces_same_instance() {
     $inject= new Injector(Bindings::using()->singleton(Storage::class, FileSystem::class));
     $a= $inject->get(Storage::class);


### PR DESCRIPTION
Extends https://github.com/xp-forge/inject/pull/23 and adds the possibility to pass instances to the `singleton()` method.

```php
$injector= new Injector(Bindings::using()
  ->singleton(Signing::class)                        // Binds a single Signing instance to Singing
  ->singleton(Algorithm::class, SHA256::class)       // Binds a single SHA256 instance to Algorithm
  ->singleton(Storage::class, new InFileSystem('.')) // 🆕 Always returns the instance passed
);
```

While the upper two provide lazily instantiated singletons, this new functionality offers an eager version.