### PR TITLE
Add Injector::implementations() to select implementations for a given type

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Inject
 [![BSD Licence](https://raw.githubusercontent.com/xp-framework/web/master/static/licence-bsd.png)](https://github.com/xp-framework/core/blob/master/LICENCE.md)
 [![Requires PHP 7.4+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-7_4plus.svg)](http://php.net/)
 [![Supports PHP 8.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-8_0plus.svg)](http://php.net/)
-[![Latest Stable Version](https://poser.pugx.org/xp-forge/inject/version.png)](https://packagist.org/packages/xp-forge/inject)
+[![Latest Stable Version](https://poser.pugx.org/xp-forge/inject/version.svg)](https://packagist.org/packages/xp-forge/inject)
 
 The inject package contains the XP framework's dependency injection API. Its entry point class is the "Injector".
 
 Binding
 -------
-Values can be bound to the injector by using its `bind()` method. It accepts the type to bind to, an optional name and these different scenarios:
+Implementations can be bound to the injector by using its `bind()` method. It accepts the type to bind to, an optional name and these different scenarios:
 
 * **Binding a class**: The typical usecase, where we bind an interface to its concrete implementation.
 * **Binding an instance**: By binding a type to an existing instance, we can create a *singleton* model.

--- a/src/main/php/inject/Implementations.class.php
+++ b/src/main/php/inject/Implementations.class.php
@@ -18,14 +18,20 @@ class Implementations {
     $this->bindings= $bindings;
   }
 
-  /**
-   * Returns the default implementation
-   * 
-   * @return T
-   */
+  /** Returns the default implementation */
   #[Generic(return: 'T')]
   public function default() {
     return current($this->bindings)->resolve($this->inject);
+  }
+
+  /** Returns all implementations */
+  #[Generic(return: '[:T]')]
+  public function all() {
+    $r= [];
+    foreach ($this->bindings as $name => $binding) {
+      $r[$name]= $binding->resolve($this->inject);
+    }
+    return $r;
   }
 
   /**

--- a/src/main/php/inject/Implementations.class.php
+++ b/src/main/php/inject/Implementations.class.php
@@ -36,7 +36,7 @@ class Implementations {
    * @throws inject.ProvisionException if there is no such implementation
    */
   #[Generic(return: 'T')]
-  public function named($name) {
+  public function named(string $name) {
     if ($binding= $this->bindings[$name] ?? null) {
       return $binding->resolve($this->inject);
     }

--- a/src/main/php/inject/Implementations.class.php
+++ b/src/main/php/inject/Implementations.class.php
@@ -4,7 +4,7 @@ use lang\Generic;
 
 /** @test inject.unittest.ImplementationsTest */
 #[Generic(self: 'T')]
-class Implementations {
+class Implementations implements Binding {
   private $inject, $bindings;
 
   /**
@@ -48,5 +48,25 @@ class Implementations {
     }
 
     throw new ProvisionException('No implementation named "'.$name.'"');
+  }
+
+  /**
+   * Resolves this binding and returns the instance
+   *
+   * @param  inject.Injector $injector
+   * @return var
+   */
+  public function resolve($injector) {
+    return $this;
+  }
+
+  /**
+   * Returns a provider for this binding
+   *
+   * @param  inject.Injector $injector
+   * @return inject.Provider<?>
+   */
+  public function provider($injector) {
+    return $this;
   }
 }

--- a/src/main/php/inject/Implementations.class.php
+++ b/src/main/php/inject/Implementations.class.php
@@ -1,0 +1,46 @@
+<?php namespace inject;
+
+use lang\Generic;
+
+/** @test inject.unittest.ImplementationsTest */
+#[Generic(self: 'T')]
+class Implementations {
+  private $inject, $bindings;
+
+  /**
+   * Creates a new instance
+   *
+   * @param inject.Injector $inject
+   * @param [:inject.Binding] $bindings
+   */
+  public function __construct(Injector $inject, array $bindings) {
+    $this->inject= $inject;
+    $this->bindings= $bindings;
+  }
+
+  /**
+   * Returns the default implementation
+   * 
+   * @return T
+   */
+  #[Generic(return: 'T')]
+  public function default() {
+    return current($this->bindings)->resolve($this->inject);
+  }
+
+  /**
+   * Returns the implementation for a given name
+   * 
+   * @param  string $name
+   * @return T
+   * @throws inject.ProvisionException if there is no such implementation
+   */
+  #[Generic(return: 'T')]
+  public function named($name) {
+    if ($binding= $this->bindings[$name] ?? null) {
+      return $binding->resolve($this->inject);
+    }
+
+    throw new ProvisionException('No implementation named "'.$name.'"');
+  }
+}

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -212,7 +212,7 @@ class Injector {
       } else if ($t instanceof Nullable) {
         return $this->binding($t->underlyingType(), $name);
       } else if (self::$IMPLEMENTATIONS->isAssignableFrom($t)) {
-        return new InstanceBinding($this->implementations($t->genericArguments()[0]));
+        return $this->implementations($t->genericArguments()[0]);
       } else if (self::$PROVIDER->isAssignableFrom($t)) {
         $literal= $t->genericArguments()[0]->literal();
         if ($binding= $this->bindings[$literal][$name] ?? null) {

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -94,16 +94,14 @@ class Injector {
    * Returns implementations for a given type
    *
    * @param  string|lang.Type $type
-   * @return inject.Implementations<?>
-   * @throws inject.ProvisionException
+   * @return ?inject.Implementations<?>
    */
   public function implementations($type) {
     $t= $type instanceof Type ? $type : Type::forName($type);
     if ($bindings= $this->bindings[$t->literal()] ?? null) {
       return self::$IMPLEMENTATIONS->base()->newGenericType([$t])->newInstance($this, $bindings);
     }
-
-    throw new ProvisionException('No implementations for type '.$t);
+    return null;
   }
 
   /**
@@ -212,7 +210,7 @@ class Injector {
       } else if ($t instanceof Nullable) {
         return $this->binding($t->underlyingType(), $name);
       } else if (self::$IMPLEMENTATIONS->isAssignableFrom($t)) {
-        return $this->implementations($t->genericArguments()[0]);
+        return $this->implementations($t->genericArguments()[0]) ?? Bindings::$ABSENT;
       } else if (self::$PROVIDER->isAssignableFrom($t)) {
         $literal= $t->genericArguments()[0]->literal();
         if ($binding= $this->bindings[$literal][$name] ?? null) {

--- a/src/main/php/inject/Injector.class.php
+++ b/src/main/php/inject/Injector.class.php
@@ -90,6 +90,22 @@ class Injector {
   }
 
   /**
+   * Returns implementations for a given type
+   *
+   * @param  string|lang.Type $type
+   * @return inject.Implementations
+   * @throws inject.ProvisionException
+   */
+  public function implementations($type) {
+    $t= $type instanceof Type ? $type : Type::forName($type);
+    if ($bindings= $this->bindings[$t->literal()] ?? null) {
+      return new Implementations($this, $bindings);
+    }
+
+    throw new ProvisionException('No implementations for type '.$t);
+  }
+
+  /**
    * Returns the lookup if it provides a value, null otherwise
    *
    * @param  inject.Binding $lookup

--- a/src/test/php/inject/unittest/ImplementationsTest.class.php
+++ b/src/test/php/inject/unittest/ImplementationsTest.class.php
@@ -1,0 +1,46 @@
+<?php namespace inject\unittest;
+
+use inject\unittest\fixture\{URI, Endpoint};
+use inject\{Injector, ProvisionException};
+use test\{Assert, Before, Expect, Test, Values};
+
+class ImplementationsTest {
+  private $uris;
+
+  #[Before]
+  private function uris() {
+    $this->uris= [
+      'dev'  => new URI('http://localhost'),
+      'prod' => new URI('https://example.com'), 
+    ];
+  }
+
+  /** @return inject.Injector */
+  private function fixture() {
+    $fixture= new Injector();
+    foreach ($this->uris as $name => $uri) {
+      $fixture->bind(URI::class, $uri, $name);
+    }
+    return $fixture;
+  }
+
+  #[Test, Values(['dev', 'prod'])]
+  public function implementations_named($name) {
+    Assert::equals($this->uris[$name], $this->fixture()->implementations(URI::class)->named($name));
+  }
+
+  #[Test]
+  public function default_implementation() {
+    Assert::equals($this->uris['dev'], $this->fixture()->implementations(URI::class)->default());
+  }
+
+  #[Test, Expect(ProvisionException::class)]
+  public function no_implementations() {
+    $this->fixture()->implementations(Endpoint::class);
+  }
+
+  #[Test, Expect(ProvisionException::class)]
+  public function unknown_implementation() {
+    $this->fixture()->implementations(URI::class)->named('stage');
+  }
+}

--- a/src/test/php/inject/unittest/ImplementationsTest.class.php
+++ b/src/test/php/inject/unittest/ImplementationsTest.class.php
@@ -34,13 +34,13 @@ class ImplementationsTest {
     Assert::equals($this->uris['dev'], $this->fixture()->implementations(URI::class)->default());
   }
 
-  #[Test, Expect(ProvisionException::class)]
-  public function no_implementations() {
-    $this->fixture()->implementations(Endpoint::class);
+  #[Test]
+  public function no_implementations_returning_null() {
+    Assert::null($this->fixture()->implementations(Endpoint::class));
   }
 
   #[Test, Expect(ProvisionException::class)]
-  public function unknown_implementation() {
+  public function unknown_named_implementation() {
     $this->fixture()->implementations(URI::class)->named('stage');
   }
 

--- a/src/test/php/inject/unittest/ImplementationsTest.class.php
+++ b/src/test/php/inject/unittest/ImplementationsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace inject\unittest;
 
-use inject\unittest\fixture\{URI, Endpoint};
+use inject\unittest\fixture\{URI, Endpoint, Service};
 use inject\{Injector, ProvisionException};
 use test\{Assert, Before, Expect, Test, Values};
 
@@ -42,5 +42,11 @@ class ImplementationsTest {
   #[Test, Expect(ProvisionException::class)]
   public function unknown_implementation() {
     $this->fixture()->implementations(URI::class)->named('stage');
+  }
+
+  #[Test]
+  public function inject() {
+    $fixture= $this->fixture();
+    Assert::equals($this->uris, $fixture->get(Service::class)->uris);
   }
 }

--- a/src/test/php/inject/unittest/fixture/Creation.class.php
+++ b/src/test/php/inject/unittest/fixture/Creation.class.php
@@ -4,4 +4,7 @@ class Creation {
 
   /** Create fluent interface for URIs */
   public function __construct(URI $uri) { /* ... */ }
+
+  /** @return string */
+  public function create() { /* ... */ }
 }

--- a/src/test/php/inject/unittest/fixture/Service.class.php
+++ b/src/test/php/inject/unittest/fixture/Service.class.php
@@ -1,0 +1,10 @@
+<?php namespace inject\unittest\fixture;
+
+class Service {
+  public $uris;
+
+  /** @param inject.Implementations<inject.unittest.fixture.URI> $uris */
+  public function __construct($uris) {
+    $this->uris= $uris->all();
+  }
+}

--- a/src/test/php/inject/unittest/fixture/URI.class.php
+++ b/src/test/php/inject/unittest/fixture/URI.class.php
@@ -1,7 +1,10 @@
 <?php namespace inject\unittest\fixture;
 
 class URI {
+  private $backing;
 
   /** @param string|inject.unittest.fixture.Creation $arg */
-  public function __construct($arg) { /* ... */ }
+  public function __construct($arg) {
+    $this->backing= $arg instanceof Creation ? $arg->create() : (string)$arg;
+  }
 }


### PR DESCRIPTION
### Previously:

```php
use inject\{Injector, ProvisionException};

class Prompts {
  public function __construct(private Injector $inject) { }

  public function send($prompt, $model) {
    if ($instance= $this->injector->get(Model::class, $model)) {
      return $instance->send($prompt);
    }
    throw new ProvisionException('No such model '.$model);
  }
}

$prompts= (new Injector(/* ... */))->get(Prompts::class);
```

### New alternative:

```php
use inject\Injector;

class Prompts {

  /** @param inject.Implementations<Model> $implementations */
  public function __construct(private $implementations) { }

  public function send($prompt, $model) {
    return $this->implementations->named($model)->send($prompt);
  }
}

$prompts= (new Injector(/* ... */))->get(Prompts::class);
```
